### PR TITLE
skip parts that are missing version1 fields

### DIFF
--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -251,12 +251,12 @@ def filter_compatible(parts: Dataset, version: Version) -> Dataset:
     """Filters `parts` by `version`."""
     result = []
     for row in parts:
-        pid = get_partID(row)
+        part_id = get_partID(row)
         if not (is_compatible(row, version)):
-            warning(f'skipping incompatible part: {pid}')
+            warning(f'skipping incompatible part: {part_id}')
             continue
         if version.major == 1 and not has_mapping(row, version):
-            error(f'skipping part with missing version1 fields: {pid}')
+            error(f'skipping part with missing version1 fields: {part_id}')
             continue
         result.append(row)
     return result

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from logging import warning
+from logging import error, warning
 from semver import Version
 from typing import DefaultDict, Dict, List, Optional, Set
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1,8 +1,8 @@
 import unittest
 
 import common
-from part_tables import is_compatible
-from versions import parse_version
+from part_tables import get_mappings, is_compatible
+from versions import Version, parse_version
 
 common.unused_import_dummy = 1
 
@@ -31,6 +31,42 @@ class TestVersionCompat(unittest.TestCase):
     def test_incomplete(self):
         row = get_row('2', '2.0', True)
         self.assertTrue(is_compatible(row, parse_version('2.0.')))
+
+
+class TestVersion1FieldsExist(unittest.TestCase):
+    parts_pass = [
+        {
+            'version1Location': 'tables',
+            'version1Table': 'a',
+        },
+        {
+            'version1Location': 'variables',
+            'version1Variable': 'b',
+        },
+        {
+            'version1Location': 'variableCategories',
+            'version1Category': 'c;d',
+        }
+    ]
+    parts_fail = [
+        {
+            'version1Table': 'a',
+        },
+        {
+            'version1Location': 'variables',
+        },
+        {
+            'version1Location': 'variableCategories',
+            'version1Category': '',
+        }
+    ]
+
+    def test(self):
+        v = Version(major = 1)
+        id_list_pass = [get_mappings(p, v) for p in self.parts_pass]
+        id_list_fail = [get_mappings(p, v) for p in self.parts_fail]
+        self.assertEqual(id_list_pass, [['a'], ['b'], ['c', 'd']])
+        self.assertEqual(id_list_fail, [None, None, None])
 
 
 if __name__ == '__main__':

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -62,7 +62,7 @@ class TestVersion1FieldsExist(unittest.TestCase):
     ]
 
     def test(self):
-        v = Version(major = 1)
+        v = Version(major=1)
         id_list_pass = [get_mappings(p, v) for p in self.parts_pass]
         id_list_fail = [get_mappings(p, v) for p in self.parts_fail]
         self.assertEqual(id_list_pass, [['a'], ['b'], ['c', 'd']])


### PR DESCRIPTION
when generating a schema for v1, all parts need to have version1 fields

fixes #70.