### PR TITLE
map odm datatypes to cerberus schema types

### DIFF
--- a/assets/validation-rules/invalid-category/schema-v1.yml
+++ b/assets/validation-rules/invalid-category/schema-v1.yml
@@ -7,7 +7,7 @@ schema:
       type: dict
       schema:
         Collection:
-          # type: string
+          type: string
           allowed:
           - Comp3h
           - Comp8h

--- a/assets/validation-rules/invalid-category/schema-v2.yml
+++ b/assets/validation-rules/invalid-category/schema-v2.yml
@@ -6,7 +6,7 @@ schema:
       type: dict
       schema:
         coll:
-          # type: string
+          type: string
           allowed:
           - comp3h
           - comp8h

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -48,7 +48,8 @@ def missing_mandatory_column():
                     continue
                 attr_meta = get_attr_meta(attr, table_id0, ver)
                 update_schema(schema, table_id1, attr_id1, rule_id,
-                              cerb_rule, table_meta, attr_meta)
+                              cerb_rule, attr.get(pt.DATA_TYPE),
+                              table_meta, attr_meta)
         return schema
 
     return Rule(
@@ -80,7 +81,8 @@ def invalid_category():
                 cerb_rule = (cerb_rule_key, cat_ids1)
                 attr_meta = get_catset_meta(table_id0, cs, categories, ver)
                 update_schema(schema, table_id1, attr_id1, rule_id,
-                              cerb_rule, table_meta, attr_meta)
+                              cerb_rule, attr.get(pt.DATA_TYPE),
+                              table_meta, attr_meta)
         return schema
 
     return Rule(

--- a/src/odm_validation/schemas.py
+++ b/src/odm_validation/schemas.py
@@ -46,7 +46,7 @@ def init_attr_schema(attr_id: str, rule_id: str, cerb_rule: tuple,
     return result
 
 
-def parse_odm_datatype(part_id, odm_datatype) -> Optional[str]:
+def parse_odm_datatype(odm_datatype) -> Optional[str]:
     """returns the cerberus-equivalent type"""
     t = odm_datatype
     if not t:
@@ -55,12 +55,12 @@ def parse_odm_datatype(part_id, odm_datatype) -> Optional[str]:
         return 'string'
     if t in ['integer', 'float']:
         return t
-    warning(f'part {part_id}: type {odm_datatype} is not implemented')
+    warning(f'odm datatype {odm_datatype} is not implemented')
 
 
 def update_schema(schema, table_id, attr_id, rule_id, cerb_rule,
                   odm_datatype: str, table_meta: Meta, attr_meta: Meta):
-    cerb_type = parse_odm_datatype(attr_id, odm_datatype)
+    cerb_type = parse_odm_datatype(odm_datatype)
     attr_schema = init_attr_schema(attr_id, rule_id, cerb_rule, cerb_type,
                                    attr_meta)
     table_schema = init_table_schema(table_id, table_meta, attr_schema)

--- a/src/odm_validation/schemas.py
+++ b/src/odm_validation/schemas.py
@@ -1,3 +1,6 @@
+from logging import warning
+from typing import Optional
+
 from part_tables import Meta
 from stdext import deep_update
 
@@ -19,8 +22,8 @@ def init_table_schema(table_id, table_meta, attr_schema):
 
 
 def init_attr_schema(attr_id: str, rule_id: str, cerb_rule: tuple,
-                     meta: Meta):
-    return {
+                     cerb_type: Optional[str], meta: Meta):
+    result = {
         attr_id: {
             cerb_rule[0]: cerb_rule[1],
             'meta': [
@@ -38,10 +41,27 @@ def init_attr_schema(attr_id: str, rule_id: str, cerb_rule: tuple,
             ]
         }
     }
+    if cerb_type:
+        result[attr_id]['type'] = cerb_type
+    return result
+
+
+def parse_odm_datatype(part_id, odm_datatype) -> Optional[str]:
+    """returns the cerberus-equivalent type"""
+    t = odm_datatype
+    if not t:
+        return
+    if t in ['categorical', 'varchar']:
+        return 'string'
+    if t in ['integer', 'float']:
+        return t
+    warning(f'part {part_id}: type {odm_datatype} is not implemented')
 
 
 def update_schema(schema, table_id, attr_id, rule_id, cerb_rule,
-                  table_meta: Meta, attr_meta: Meta):
-    attr_schema = init_attr_schema(attr_id, rule_id, cerb_rule, attr_meta)
+                  odm_datatype: str, table_meta: Meta, attr_meta: Meta):
+    cerb_type = parse_odm_datatype(attr_id, odm_datatype)
+    attr_schema = init_attr_schema(attr_id, rule_id, cerb_rule, cerb_type,
+                                   attr_meta)
     table_schema = init_table_schema(table_id, table_meta, attr_schema)
     deep_update(table_schema, schema)


### PR DESCRIPTION
previously we didn't map odm datatypes to cerberus datatypes during schema generation. this fixes that.

ex: `dataType: varchar` --> `type: string`