### PR TITLE
only test doc-gen on pull request

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,6 +1,6 @@
 name: Test documentation generation
 on:
-  push:
+  pull_request:
     branches-ignore:
     - main
 jobs:


### PR DESCRIPTION
only trigger on pull request, otherwise it'll run on every push to every branch before it's ready for a PR.