### PR TITLE
implement min/max value rules

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -13,4 +13,5 @@ jobs:
         python-version: '3.10'
         cache: 'pip' # caching pip dependencies
     - run: pip install -r requirements.txt
+    - run: pip install -r tests/requirements.txt
     - run: python -m unittest discover tests

--- a/assets/validation-rules/greater-than-max-value/error-report-1.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-1.json
@@ -7,12 +7,17 @@
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": 91
+                "geoLat": 91,
+                "geoLong": 90.2
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "90"
-            },
+            "invalidValue": 91,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "maxValue": "90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 91 in row 1 in column geoLat in table sites is greater than the allowable maximum value of 90"
         },
         {
@@ -22,18 +27,19 @@
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
+                "geoLat": 91,
                 "geoLong": 90.2
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "90.15"
-            },
+            "invalidValue": 90.2,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "maxValue": "90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 90.2 in row 1 in column geoLong in table sites is greater than the allowable maximum value of 90.15"
         }
     ],
     "warnings": []
 }
-
-
-
-

--- a/assets/validation-rules/greater-than-max-value/error-report-2.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-2.json
@@ -7,12 +7,17 @@
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "91"
+                "geoLat": 91,
+                "geoLong": 90.2
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "90"
-            },
+            "invalidValue": 91,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "maxValue": "90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 91 in row 1 in column geoLat in table sites is greater than the allowable maximum value of 90"
         },
         {
@@ -22,44 +27,61 @@
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "90.2"
+                "geoLat": 91,
+                "geoLong": 90.2
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "90.15"
-            },
+            "invalidValue": 90.2,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "maxValue": "90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 90.2 in row 1 in column geoLong in table sites is greater than the allowable maximum value of 90.15"
         }
     ],
     "warnings": [
         {
-            "warningType": "greater_than_max_value",
+            "warningType": "_coercion",
+	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLat",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "91"
+                "geoLat": "91",
+                "geoLong": "90.2"
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "90"
-            },
+            "invalidValue": "91",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "maxValue": "90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 91 in row 1 in column geoLat in table sites is a string and was coerced into a number"
         },
         {
-            "warningType": "greater_than_max_value",
+            "warningType": "_coercion",
+	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLong",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
+                "geoLat": "91",
                 "geoLong": "90.2"
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "90.15"
-            },
+            "invalidValue": "90.2",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "maxValue": "90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 90.2 in row 1 in column geoLong in table sites is a string and was coerced into a number"
         }
     ]

--- a/assets/validation-rules/greater-than-max-value/error-report-3.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-3.json
@@ -1,33 +1,45 @@
 {
     "errors": [
         {
-            "errorType": "greater_than_max_value",
+            "errorType": "_coercion",
+            "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLat",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "a"
+                "geoLat": "a",
+                "geoLong": "b"
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "90"
-            },
+            "invalidValue": "a",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "maxValue": "90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value a in row 1 in column geoLat in table sites cannot be coerced into a number"
         },
         {
-            "errorType": "greater_than_max_value",
+            "errorType": "_coercion",
+            "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLong",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
+                "geoLat": "a",
                 "geoLong": "b"
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "90.15"
-            },
+            "invalidValue": "b",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "maxValue": "90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value b in row 1 in column geoLong in table sites cannot be coerced into a number"
         }
     ],

--- a/assets/validation-rules/greater-than-max-value/error-report-4.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-4.json
@@ -2,33 +2,45 @@
     "errors": [],
     "warnings": [
         {
-            "warningType": "greater_than_max_value",
+            "warningType": "_coercion",
+	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLat",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "89"
+                "geoLat": "89",
+                "geoLong": "90.1"
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "90"
-            },
+            "invalidValue": "89",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "maxValue": "90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 89 in row 1 in column geoLat in table sites is a string and was coerced into a number"
         },
         {
-            "warningType": "greater_than_max_value",
+            "warningType": "_coercion",
+	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLong",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
+                "geoLat": "89",
                 "geoLong": "90.1"
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "90.1"
-            },
+            "invalidValue": "90.1",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "maxValue": "90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value 90.1 in row 1 in column geoLong in table sites is a string and was coerced into a number"
         }
     ]

--- a/assets/validation-rules/greater-than-max-value/invalid-dataset-1.yml
+++ b/assets/validation-rules/greater-than-max-value/invalid-dataset-1.yml
@@ -1,4 +1,3 @@
-sites:
-  - siteID: "1"
-    geoLat: 91
-    geoLong: 90.2
+- siteID: "1"
+  geoLat: 91
+  geoLong: 90.2

--- a/assets/validation-rules/greater-than-max-value/parts.csv
+++ b/assets/validation-rules/greater-than-max-value/parts.csv
@@ -1,5 +1,5 @@
-partID,partType,sites,dataType,maxValue,version1Location,version1Table,version1Variable
-sites,table,NA,NA,NA,tables,Site,NA
-geoLat,attribute,header,integer,90,variables,Site,Latitude
-geoLong,attribute,header,float,90.15,variables,Site,Longitude
-geoEPSG,attribute,header,integer,NA,variables,Site,LatitudeEPSG
+partID,partType,sites,dataType,maxValue,version1Location,version1Table,version1Variable,status
+sites,table,NA,NA,NA,tables,Site,NA,active
+geoLat,attribute,header,integer,90,variables,Site,Latitude,active
+geoLong,attribute,header,float,90.15,variables,Site,Longitude,active
+geoEPSG,attribute,header,integer,NA,variables,Site,LatitudeEPSG,active

--- a/assets/validation-rules/greater-than-max-value/schema-v1.yml
+++ b/assets/validation-rules/greater-than-max-value/schema-v1.yml
@@ -6,9 +6,11 @@ schema:
       type: dict
       schema:
         Latitude:
+          type: integer
+          coerce: integer
           max: 90
           meta:
-          - ruleId: greater_than_max_value
+          - ruleID: greater_than_max_value
             meta:
             - partID: geoLat
               sites: header
@@ -17,9 +19,11 @@ schema:
               version1Variable: Latitude
               maxValue: '90'
         Longitude:
+          type: float
+          coerce: float
           max: 90.15
           meta:
-          - ruleId: greater_than_max_value
+          - ruleID: greater_than_max_value
             meta:
             - partID: geoLong
               sites: header
@@ -27,8 +31,8 @@ schema:
               version1Table: Site
               version1Variable: Longitude
               maxValue: '90.15'
-    meta:
-      - partID: sites
-        partType: table
-        version1Location: tables
-        version1Table: Site
+      meta:
+        - partID: sites
+          partType: table
+          version1Location: tables
+          version1Table: Site

--- a/assets/validation-rules/greater-than-max-value/schema-v2.yml
+++ b/assets/validation-rules/greater-than-max-value/schema-v2.yml
@@ -6,19 +6,25 @@ schema:
       type: dict
       schema:
         geoLat:
+          type: integer
+          coerce: integer
           max: 90
           meta:
-          - ruleId: greater_than_max_value
+          - ruleID: greater_than_max_value
             meta:
             - partID: geoLat
               maxValue: '90'
+              sites: header
         geoLong:
+          type: float
+          coerce: float
           max: 90.15
           meta:
-            - ruleId: greater_than_max_value
+            - ruleID: greater_than_max_value
               meta:
                 - partID: geoLong
                   maxValue: '90.15'
-    meta:
-      - partID: sites
-        partType: table
+                  sites: header
+      meta:
+        - partID: sites
+          partType: table

--- a/assets/validation-rules/invalid-category/error-report.json
+++ b/assets/validation-rules/invalid-category/error-report.json
@@ -1,41 +1,39 @@
 {
     "errors": [
-	{
-	    "errorType": "invalid_category",
-	    "tableName": "samples",
-	    "columnName": "coll",
-	    "rowNumber": 1,
-	    "row": {
-		"coll": "flow"
-	    },
-	    "invalidValue": "flow",
-	    "validationRuleFields": [
-		[
-		    {
-			"partID": "coll",
-			"samples": "header",
-			"dataType": "categorical",
-			"catSetID": "collectCat"
-		    },
-		    {
-			"partID": "comp3h",
-			"partType": "category",
-			"catSetID": "collectCat"
-		    },
-		    {
-			"partID": "comp8h",
-			"partType": "category",
-			"catSetID": "collectCat"
-		    },
-		    {
-			"partID": "flowPr",
-			"partType": "category",
-			"catSetID": "collectCat"
-		    }
-		]
-	    ],
-	    "message": "Invalid category flow found in row 1 for column coll in table samples"
-	}
+        {
+            "errorType": "invalid_category",
+            "tableName": "samples",
+            "columnName": "coll",
+            "rowNumber": 1,
+            "row": {
+                "coll": "flow"
+            },
+            "invalidValue": "flow",
+            "validationRuleFields": [
+                {
+                    "partID": "coll",
+                    "samples": "header",
+                    "dataType": "categorical",
+                    "catSetID": "collectCat"
+                },
+                {
+                    "partID": "comp3h",
+                    "partType": "category",
+                    "catSetID": "collectCat"
+                },
+                {
+                    "partID": "comp8h",
+                    "partType": "category",
+                    "catSetID": "collectCat"
+                },
+                {
+                    "partID": "flowPr",
+                    "partType": "category",
+                    "catSetID": "collectCat"
+                }
+            ],
+            "message": "Invalid category flow found in row 1 for column coll in table samples"
+        }
     ],
     "warnings": []
 }

--- a/assets/validation-rules/invalid-category/schema-v1.yml
+++ b/assets/validation-rules/invalid-category/schema-v1.yml
@@ -7,7 +7,6 @@ schema:
       type: dict
       schema:
         Collection:
-          # type: string
           allowed:
           - Comp3h
           - Comp8h

--- a/assets/validation-rules/invalid-category/schema-v2.yml
+++ b/assets/validation-rules/invalid-category/schema-v2.yml
@@ -6,7 +6,6 @@ schema:
       type: dict
       schema:
         coll:
-          # type: string
           allowed:
           - comp3h
           - comp8h

--- a/assets/validation-rules/less-than-min-value/error-report-1.json
+++ b/assets/validation-rules/less-than-min-value/error-report-1.json
@@ -6,13 +6,18 @@
             "columnName": "geoLat",
             "rowNumber": 1,
             "row": {
-                "siteID": "1",
-                "geoLat": -91
+                "siteID": 1,
+                "geoLat": -91,
+                "geoLong": -90.2
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "-90"
-            },
+            "invalidValue": -91,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "minValue": "-90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -91 in row 1 in column geoLat in table sites is less than the allowable minimum value of -90"
         },
         {
@@ -21,13 +26,18 @@
             "columnName": "geoLong",
             "rowNumber": 1,
             "row": {
-                "siteID": "1",
-                "geoLat": -90.2
+                "siteID": 1,
+                "geoLat": -91,
+                "geoLong": -90.2
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "-90.15"
-            },
+	    "invalidValue": -90.2,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "minValue": "-90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -90.2 in row 1 in column geoLong in table sites is less than the allowable minimum value of -90.15"
         }
     ],

--- a/assets/validation-rules/less-than-min-value/error-report-2.json
+++ b/assets/validation-rules/less-than-min-value/error-report-2.json
@@ -7,12 +7,17 @@
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "-91"
+                "geoLat": -91,
+                "geoLong": -90.2
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "-90"
-            },
+            "invalidValue": -91,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "minValue": "-90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -91 in row 1 in column geoLat in table sites is less than the allowable minimum value of -90"
         },
         {
@@ -22,44 +27,61 @@
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "-90.2"
+                "geoLat": -91,
+                "geoLong": -90.2
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "-90.15"
-            },
+            "invalidValue": -90.2,
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "minValue": "-90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -90.2 in row 1 in column geoLong in table sites is less than the allowable minimum value of -90.15"
         }
     ],
     "warnings": [
         {
-            "warningType": "less_than_min_value",
+            "warningType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLat",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "-91"
+                "geoLat": "-91",
+                "geoLong": "-90.2"
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "-90"
-            },
+            "invalidValue": "-91",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "minValue": "-90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -91 in row 1 in column geoLat in table sites is a string and was coerced into a number"
         },
         {
-            "warningType": "less_than_min_value",
+            "warningType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLong",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "-90.2"
+                "geoLat": "-91",
+                "geoLong": "-90.2"
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "-90.15"
-            },
+            "invalidValue": "-90.2",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "minValue": "-90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -90.2 in row 1 in column geoLong in table sites is a string and was coerced into a number"
         }
     ]

--- a/assets/validation-rules/less-than-min-value/error-report-3.json
+++ b/assets/validation-rules/less-than-min-value/error-report-3.json
@@ -1,33 +1,45 @@
 {
     "errors": [
         {
-            "errorType": "less_than_min_value",
+            "errorType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLat",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "a"
+                "geoLat": "a",
+                "geoLong": "b"
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "-90"
-            },
+            "invalidValue": "a",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "minValue": "-90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value a in row 1 in column geoLat in table sites cannot be coerced into a number"
         },
         {
-            "errorType": "less_than_min_value",
+            "errorType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLong",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "b"
+                "geoLat": "a",
+                "geoLong": "b"
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "-90.15"
-            },
+            "invalidValue": "b",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "minValue": "-90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value b in row 1 in column geoLong in table sites cannot be coerced into a number"
         }
     ],

--- a/assets/validation-rules/less-than-min-value/error-report-4.json
+++ b/assets/validation-rules/less-than-min-value/error-report-4.json
@@ -2,33 +2,45 @@
     "errors": [],
     "warnings": [
         {
-            "warningType": "less_than_min_value",
+            "warningType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLat",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
-                "geoLat": "-89"
+                "geoLat": "-89",
+                "geoLong": "-90"
             },
-            "validationRules": {
-                "partID": "geoLat",
-                "min": "-90"
-            },
+            "invalidValue": "-89",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "minValue": "-90",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -89 in row 1 in column geoLat in table sites is a string and was coerced into a number"
         },
         {
-            "warningType": "less_than_min_value",
+            "warningType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLong",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
+                "geoLat": "-89",
                 "geoLong": "-90"
             },
-            "validationRules": {
-                "partID": "geoLong",
-                "min": "-90.15"
-            },
+            "invalidValue": "-90",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "minValue": "-90.15",
+                    "sites": "header"
+                }
+            ],
             "message": "Value -90 in row 1 in column geoLong in table sites is a string and was coerced into a number"
         }
     ]

--- a/assets/validation-rules/less-than-min-value/invalid-dataset-1.yml
+++ b/assets/validation-rules/less-than-min-value/invalid-dataset-1.yml
@@ -1,4 +1,3 @@
-sites:
-  - siteID: 1
-    geoLat: -91
-    geoLong: -90.2
+- siteID: 1
+  geoLat: -91
+  geoLong: -90.2

--- a/assets/validation-rules/less-than-min-value/parts.csv
+++ b/assets/validation-rules/less-than-min-value/parts.csv
@@ -1,5 +1,5 @@
-partID,partType,sites,dataType,minValue,version1Location,version1Table,version1Variable
-sites,table,NA,NA,NA,tables,Site,NA
-geoLat,attribute,header,integer,-90,variables,Site,Latitude
-geoLong,attribute,header,float,-90.15,variables,Site,Longitude
-geoEPSG,attribute,header,integer,NA,variables,Site,LatitudeEPSG
+partID,partType,sites,dataType,minValue,version1Location,version1Table,version1Variable,status
+sites,table,NA,NA,NA,tables,Site,NA,active
+geoLat,attribute,header,integer,-90,variables,Site,Latitude,active
+geoLong,attribute,header,float,-90.15,variables,Site,Longitude,active
+geoEPSG,attribute,header,integer,NA,variables,Site,LatitudeEPSG,active

--- a/assets/validation-rules/less-than-min-value/schema-v1.yml
+++ b/assets/validation-rules/less-than-min-value/schema-v1.yml
@@ -6,9 +6,11 @@ schema:
       type: dict
       schema:
         Latitude:
+          type: integer
+          coerce: integer
           min: -90
           meta:
-          - ruleId: less_than_min_value
+          - ruleID: less_than_min_value
             meta:
             - partID: geoLat
               sites: header
@@ -17,9 +19,11 @@ schema:
               version1Variable: Latitude
               minValue: "-90"
         Longitude:
+          type: float
+          coerce: float
           min: -90.15
           meta:
-          - ruleId: less_than_min_value
+          - ruleID: less_than_min_value
             meta:
             - partID: geoLong
               sites: header
@@ -27,8 +31,8 @@ schema:
               version1Table: Site
               version1Variable: Longitude
               minValue: "-90.15"
-    meta:
-      - partID: sites
-        partType: table
-        version1Location: tables
-        version1Table: Site
+      meta:
+        - partID: sites
+          partType: table
+          version1Location: tables
+          version1Table: Site

--- a/assets/validation-rules/less-than-min-value/schema-v2.yml
+++ b/assets/validation-rules/less-than-min-value/schema-v2.yml
@@ -6,19 +6,25 @@ schema:
       type: dict
       schema:
         geoLat:
+          type: integer
+          coerce: integer
           min: -90
           meta:
-          - ruleId: less_than_min_value
+          - ruleID: less_than_min_value
             meta:
             - partID: geoLat
               minValue: "-90"
+              sites: header
         geoLong:
+          type: float
+          coerce: float
           min: -90.15
           meta:
-          - ruleId: less_than_min_value
+          - ruleID: less_than_min_value
             meta:
               - partID: geoLong
                 minValue: "-90.15"
-    meta:
-      - partID: sites
-        partType: tables
+                sites: header
+      meta:
+        - partID: sites
+          partType: table

--- a/assets/validation-rules/missing-mandatory-column/error-report.json
+++ b/assets/validation-rules/missing-mandatory-column/error-report.json
@@ -9,13 +9,11 @@
                 "addL2": "123 Doe Street"
             },
             "validationRuleFields": [
-                [
-                    {
-                        "addresses": "pK",
-                        "partID": "addID",
-                        "addressesRequired": "mandatory"
-                    }
-                ]
+                {
+                    "addresses": "pK",
+                    "partID": "addID",
+                    "addressesRequired": "mandatory"
+                }
             ],
             "message": "Missing mandatory column addID in table addresses in row number 1"
         }

--- a/docs/validation-rules/greater_than_max_value.qmd
+++ b/docs/validation-rules/greater_than_max_value.qmd
@@ -28,7 +28,8 @@ If the value to be validated is not a number but can be coerced into one, then a
 pprint_csv_file(asset("invalid-dataset-2.csv"), "Invalid Dataset")
 ```
 
-and the following dataset should pass validation with a warning,
+and the following dataset should pass validation with a warning (since by
+default all CSV values are parsed as strings in Python),
 
 ```{python}
 #| echo: false
@@ -66,6 +67,7 @@ The error report for the first two cases is shown below,
 * **columnName**: The name of the column with the invalid value
 * **rowNumber**: The index of the row with the invalid value
 * **row**: The dictionary containing the invalid row
+* **invalidValue**: The invalid value
 * **validationRuleFields**: The ODM data dictionary rows used to generate this rule
 * **message**: Value \<invalid_value\> in row \<row_index\> in column \<column_name\> in table \<table_name\> is greater than the allowable maximum value of \<max_value\>
 
@@ -75,11 +77,13 @@ The error report for the third case is the identical except for the message fiel
 
 A warning is generated when the value is a not a number but is coerced into one before validation. The warning report will have the following fields,
 
-* **warningType**: greater_than_max_value
-* **tableName** The name of the table with the invalid value
+* **warningType**: _coercion
+* **coercionRules**: The list of validation rules that required this coercion
+* **tableName**: The name of the table with the invalid value
 * **columnName**: The name of the column with the invalid value
 * **rowNumber**: The index of the row with the invalid value
 * **row**: The dictionary containing the invalid row
+* **invalidValue**: The invalid value
 * **validationRuleFields**: The ODM data dictionary rows used to generate this rule
 * **message**: Value \<invalid_value\> in row \<row_index\> in column \<column_name\> in table \<table_name\> is a \<invalid_type\> and was coerced into a number
 
@@ -139,7 +143,14 @@ The `geoLat` part which is a column in the `sites` table has a `max` value of 90
 
 ## Cerberus Schema
 
-We can use the [maximum value validation](https://docs.python-cerberus.org/en/stable/validation-rules.html#min-max) rule in cerberus to implement this rule.
+We can use the [maximum value
+validation](https://docs.python-cerberus.org/en/stable/validation-rules.html#min-max)
+rule in cerberus to implement this rule. Cerberus also needs to know the data
+type when performing this validation, so we need to set
+[type](https://docs.python-cerberus.org/en/stable/validation-rules.html#type)
+and
+[coerce](https://docs.python-cerberus.org/en/stable/validation-rules.html#type)
+as well.
 
 The generated cerberus object for the example above is shown below,
 

--- a/docs/validation-rules/less_than_min_value.qmd
+++ b/docs/validation-rules/less_than_min_value.qmd
@@ -28,7 +28,8 @@ If the value to be validated is not a number but can be coerced into one, then a
 pprint_csv_file(asset("invalid-dataset-2.csv"), "Invalid Dataset")
 ```
 
-and the following dataset should pass validation with a warning,
+and the following dataset should pass validation with a warning (since by
+default all CSV values are parsed as strings in Python),
 
 ```{python}
 #| echo: false
@@ -66,6 +67,7 @@ The error report for the first two cases is shown below,
 * **columnName**: The name of the column with the invalid value
 * **rowNumber**: The index of the row with the invalid value
 * **row**: The dictionary containing the invalid row
+* **invalidValue**: The invalid value
 * **validationRuleFields**: The ODM data dictionary rows used to generate this rule
 * **message**: Value \<invalid_value\> in row \<row_index\> in column \<column_name\> in table \<table_name\> is less than the allowable minimum value of \<min_value\>
 
@@ -75,11 +77,13 @@ The error report for the third case is the identical except for the message fiel
 
 A warning is generated when the value is a not a number but is coerced into one before validation. The warning report will have the following fields,
 
-* **warningType**: less_than_min_value
-* **tableName** The name of the table with the invalid value
+* **warningType**: _coercion
+* **coercionRules**: The list of validation rules that required this coercion
+* **tableName**: The name of the table with the invalid value
 * **columnName**: The name of the column with the invalid value
 * **rowNumber**: The index of the row with the invalid value
 * **row**: The dictionary containing the invalid row
+* **invalidValue**: The invalid value
 * **validationRuleFields**: The ODM data dictionary rows used to generate this rule
 * **message**: Value \<invalid_value\> in row \<row_index\> in column \<column_name\> in table \<table_name\> is a \<invalid_type\> and was coerced into a number
 
@@ -139,7 +143,14 @@ The `geoLat` part which is a column in the `sites` table has a `minValue` value 
 
 ## Cerberus Schema
 
-We can use the [minimum value validation](https://docs.python-cerberus.org/en/stable/validation-rules.html#min-max) rule from cerberus to implement this rule.
+We can use the [minimum value
+validation](https://docs.python-cerberus.org/en/stable/validation-rules.html#min-max)
+rule from cerberus to implement this rule. Cerberus also needs to know the data
+type when performing this validation, so we need to set
+[type](https://docs.python-cerberus.org/en/stable/validation-rules.html#type)
+and
+[coerce](https://docs.python-cerberus.org/en/stable/validation-rules.html#type)
+as well.
 
 The generated cerberus object for the example above is shown below,
 

--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -1,0 +1,196 @@
+import logging
+from enum import Enum
+from typing import List, Optional
+from copy import deepcopy
+# from pprint import pprint
+
+from cerberus import Validator
+
+import part_tables as pt
+from stdext import strip_dict_key
+
+
+class LogLevel(Enum):
+    WARNING = 'warning'
+    ERROR = 'error'
+
+
+def _get_meta_rule_ids(column_meta) -> List[str]:
+    if not column_meta:
+        return []
+    return [m['ruleID'] for m in column_meta]
+
+
+def _type_name(x) -> str:
+    result = type(x).__name__
+    if result == 'int':
+        result = 'integer'
+    if result == 'str':
+        result = 'string'
+    return result
+
+
+def _gen_coercion_msg(log_lvl, table, column, row_num, value, column_meta):
+    value_type_name = _type_name(value)
+    result = (f'Value {value} in row {row_num} in column {column} '
+              f'in table {table} ')
+    if log_lvl == 'warning':
+        result += f'is a {value_type_name} and was '
+    elif log_lvl == 'error':
+        result += 'cannot be '
+    else:
+        assert False, "invalid log lvl"
+    result += 'coerced into a number'
+    return result
+
+
+def _gen_coercion_log_entry(log_lvl, table, column, row_index, row,
+                            orig_value, column_meta):
+    row_num = row_index + 1
+    rule_ids = _get_meta_rule_ids(column_meta)
+    rule_fields = pt.get_validation_rule_fields(column_meta, rule_ids)
+    msg = _gen_coercion_msg(log_lvl, table, column, row_num, orig_value,
+                            column_meta)
+    return {
+        (str(log_lvl) + 'Type'): '_coercion',
+        'coercionRules': rule_ids,
+        'tableName': table,
+        'columnName': column,
+        'rowNumber': row_num,
+        'row': row,
+        'invalidValue': orig_value,
+        'validationRuleFields': rule_fields,
+        'message': msg
+    }
+
+
+def _gen_coercion_warning(table, column, row_index, row, orig_value,
+                          column_meta):
+    return _gen_coercion_log_entry('warning', table, column, row_index, row,
+                                   orig_value, column_meta)
+
+
+def _gen_coercion_error(table, column, row_index, row, orig_value,
+                        column_meta):
+    return _gen_coercion_log_entry('error', table, column, row_index, row,
+                                   orig_value, column_meta)
+
+
+class ContextualCoercer(Validator):
+    """Construct this with the `errors` and `warnings` parameters set to
+    existing lists, to retrieve coercion errors and warnings."""
+    # This class performs coercion on data, to prepare it for the actual
+    # validation. Cerberus' native coercion doesn't give contextual info about
+    # where the coercions take place, which is why we need this custom extended
+    # class. The Cerberus validation routine, combined with the 'check_with'
+    # rule is used to implement coercion in our own context-aware way.
+    #
+    # Data is stored/passed using the `_config` dict of the base class. It can
+    # be initialized during construction by passing extra key-value parameters
+    # to the base constructor. Existing list objects must be passed to retain
+    # the data after coercion. Normal fields in this derived class doesn't seem
+    # to be able to pass state to the internal cerberus calls (like
+    # `_check_with_int`, which is why we're using this base-class field
+    # instead.
+    #
+    # Alternative solutions for coercion have been tried without luck,
+    # including:
+    # - Native coercion (no context).
+    # - Validation rule (not able to set new value for remaining rules).
+    # - Retrieving the coerced document from Cerberus' validation step didn't
+    #   seem to work either.
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.allow_unknown = True
+
+    def _extract_coercion_schema(schema):
+        """Strips `schema` of all rules except 'meta' and 'coerce', and
+        replaces 'coerce' with 'check_with'."""
+        result = deepcopy(schema)
+        for table in result.keys():
+            schema = result[table]['schema']['schema']
+            for field, rules in list(schema.items()):
+                for key in list(rules.keys()):
+                    if key == 'coerce':
+                        rules['check_with'] = rules.pop(key)
+                    elif key != 'meta':
+                        del rules[key]
+                if len(rules) == 0:
+                    del schema[field]
+        return result
+
+    def coerce(self, document, schema) -> Optional[dict]:
+        # Coercion is performed by validating using a coercion-only schema.
+        # Native cerberus normalization can't be used because it doesn't
+        # provide context. Coercions are kept track of using `_config`.
+        #
+        # Cerberus' `Validator.validate` is invoked without error handling, as
+        # we're not expecting any errors, and we're already handling errors in
+        # the `_check_with_x` functions. We are, however, logging any errors to
+        # file, just in case we miss something.
+        coercion_schema = ContextualCoercer._extract_coercion_schema(schema)
+        self.schema = coercion_schema
+        self._config["coerced_document"] = deepcopy(document)
+        if not super().validate(document):
+            logging.error(self.errors)
+        return self._config["coerced_document"]
+
+    def _log_warning(self, table, field, row_ix, row, orig_value, column_meta):
+        warning = _gen_coercion_warning(table, field, row_ix, row, orig_value,
+                                        column_meta)
+        self._config["warnings"].append(warning)
+
+    def _log_error(self, table, field, row_ix, row, orig_value, column_meta):
+        error = _gen_coercion_error(table, field, row_ix, row, orig_value,
+                                    column_meta)
+        self._config["errors"].append(error)
+
+    def _set_value(self, field, orig_value, type_class):
+        if isinstance(orig_value, type_class):
+            return
+        table = self.document_path[0]
+        row_ix = self.document_path[1]
+        row = self.document
+        column_meta = self.schema[field].get('meta')
+        try:
+            value = type_class(orig_value)
+            self._config["coerced_document"][table][row_ix][field] = value
+            self._log_warning(table, field, row_ix, row, orig_value,
+                              column_meta)
+        except ValueError:
+            value = orig_value
+            self._log_error(table, field, row_ix, row, orig_value,
+                            column_meta)
+
+    def _check_with_float(self, field, value):
+        self._set_value(field, value, float)
+
+    def _check_with_integer(self, field, value):
+        self._set_value(field, value, int)
+
+
+class OdmValidator(Validator):
+    """Must be constructed with `coercion_warnings` and `coercion_errors`
+    parameters set to existing lists."""
+    # This is the main class used for validation. It wraps the
+    # ContextualCoercer class to perform coercion before the validation step.
+
+    def __init__(self, *args, **kwargs):
+        # Cerberus is filling in `_config` with any extra key-value
+        # parameters, which is how the coercion-warning/error lists are set.
+        #
+        # Unknown fields must be allowed because we're only generating a schema
+        # for the requirements, not the optional data.
+        super().__init__(*args, **kwargs)
+        self.allow_unknown = True
+
+    def validate(self, data, schema):
+        warnings = self._config['coercion_warnings']
+        errors = self._config['coercion_errors']
+        coercer = ContextualCoercer(warnings=warnings, errors=errors)
+        coerced_data = coercer.coerce(data, schema)
+
+        validation_schema = strip_dict_key(deepcopy(schema), 'coerce')
+        result = super().validate(coerced_data, validation_schema)
+        return result

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -7,6 +7,7 @@ from logging import error, warning
 from semver import Version
 from typing import DefaultDict, Dict, List, Optional, Set
 
+from stdext import flatten
 from versions import parse_version
 
 
@@ -102,6 +103,18 @@ V1_KIND_MAP = {
     'variables': MapKind.ATTRIBUTE,
     'variableCategories': MapKind.CATEGORY,
 }
+
+
+def get_validation_rule_fields(column_meta, rule_ids: List[str]):
+    if not column_meta:
+        return []
+    assert isinstance(column_meta, list)
+    assert isinstance(column_meta[0], dict)
+    assert isinstance(column_meta[0]['meta'], list)
+    return flatten(list(
+        map(lambda x: x['meta'],
+            filter(lambda x: x['ruleID'] in rule_ids,
+                   column_meta))))
 
 
 def parse_row_version(row, field, default=None):

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -1,8 +1,10 @@
 from typing import Dict, List
+# from pprint import pprint
 
 import part_tables as pt
 from part_tables import Meta, MetaEntry, Part, PartData, PartId
-from stdext import flatten
+from schemas import init_attr_schema, init_table_schema, parse_odm_datatype
+from stdext import deep_update, flatten
 from versions import Version
 
 
@@ -14,11 +16,14 @@ def get_table_meta(table: Part, version: Version) -> Meta:
     return [m]
 
 
-def get_attr_meta(attr: Part, table_id: PartId, version: Version):
+def get_attr_meta(attr: Part, table_id: PartId, version: Version,
+                  odm_key: str = None):
     keys = [pt.PART_ID, table_id, pt.table_required_field(table_id)]
     if version.major == 1:
         keys += [pt.V1_LOCATION, pt.V1_TABLE, pt.V1_VARIABLE]
-    return [{k: attr[k] for k in keys}]
+    if odm_key:
+        keys += [odm_key]
+    return [{k: attr[k] for k in keys if k in attr}]
 
 
 def get_catset_meta(table_id: PartId, catset: Part, categories: List[Part],
@@ -76,6 +81,12 @@ def table_items(data: PartData, version: Version):
         yield (table_id0, table_id1, table)
 
 
+def table_items2(data: PartData):
+    """Iterates over all table parts from `data`."""
+    for _, td in data.table_data.items():
+        yield td.part
+
+
 def catset_items(data: PartData, version: Version):
     """Iterates over all category-set attributes.
 
@@ -93,3 +104,54 @@ def attr_items(data: PartData, table_id: PartId, version: Version):
         attr_id0 = pt.get_partID(attr)
         attr_id1 = get_mapped_attr_id(data, attr_id0, version)
         yield (attr_id0, attr_id1, attr)
+
+
+def attr_items2(data: PartData, table_id: PartId, key: str):
+    """Iterates over all attribute parts with `key`, which is part of table
+    `table_id`, from `data`."""
+    return filter(lambda part: key in part,
+                  data.table_data[table_id].attributes)
+
+
+def init_table_schema2(schema, data, table, version):
+    """This is a helper for creating the table schema, to make it easier to
+    write rule-functions. This should be prefered over using
+    `init_table_schema` directly."""
+    # This is not part of module 'schemas' due to simplicity. It has
+    # dependencies in this file and the modules may be merged soon enough.
+    table_id0 = pt.get_partID(table)
+    table_id1 = get_mapped_table_id(data, table_id0, version)
+    table_meta = get_table_meta(table, version)
+    return init_table_schema(table_id1, table_meta, {})
+
+
+def set_attr_schema(table_schema, data, table, attr, rule_id, odm_key,
+                    cerb_rule, version, typed):
+    table_id0 = pt.get_partID(table)
+    table_id1 = list(table_schema.keys())[0]
+    attr_id0 = pt.get_partID(attr)
+    attr_id1 = get_mapped_attr_id(data, attr_id0, version)
+    attr_meta = get_attr_meta(attr, table_id0, version, odm_key)
+    cerb_type = parse_odm_datatype(attr.get(pt.DATA_TYPE)) if typed else None
+    attr_schema = init_attr_schema(attr_id1, rule_id, cerb_rule, cerb_type,
+                                   attr_meta)
+    deep_update(attr_schema, table_schema[table_id1]['schema']['schema'])
+
+
+def gen_simple_schema(data: pt.PartData, ver, rule_id, odm_key, cerb_key):
+    """Provides a simple way to generate a simple schema. This should be
+    prefered to iterating over part-data directly in the rule-functions.
+
+    A simple schema simply means mapping an ODM-attribute to a cerberus schema
+    attribute without any extra fuss. Ex: minValue -> min."""
+    schema = {}
+    typed = cerb_key in {'max', 'min'}
+    for table in table_items2(data):
+        table_id0 = pt.get_partID(table)
+        table_schema = init_table_schema2(schema, data, table, ver)
+        for attr in attr_items2(data, table_id0, odm_key):
+            cerb_rule = (cerb_key, float(attr[odm_key]))
+            set_attr_schema(table_schema, data, table, attr, rule_id,
+                            odm_key, cerb_rule, ver, typed)
+        deep_update(table_schema, schema)
+    return schema

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -1,4 +1,7 @@
-"""This file defines the Rule type along with all the rule implementations."""
+"""This file defines the Rule type along with all the rule implementations.
+
+Rule functions are ordered alphabetically.
+"""
 
 from dataclasses import dataclass
 from typing import Callable, Dict, Tuple
@@ -8,6 +11,7 @@ from schemas import Schema, update_schema
 from versions import Version
 
 from rule_primitives import attr_items, \
+                            gen_simple_schema, \
                             get_attr_meta, \
                             get_catset_meta, \
                             get_table_meta, \
@@ -25,6 +29,7 @@ class Rule:
     - rule_name
     - table_id
     - value
+    - constraint
     """
     id: str
     key: str  # The Cerberus error key identifying the Rule
@@ -39,6 +44,20 @@ def init_rule(rule_id, cerb_key, error, gen_schema):
         error_template=error,
         gen_schema=gen_schema,
     )
+
+
+def greater_than_max_value():
+    rule_id = greater_than_max_value.__name__
+    odm_key = 'maxValue'
+    cerb_key = 'max'
+    err = ('Value {value} in row {row_num} in column {column_id} in table '
+           '{table_id} is greater than the allowable maximum value of '
+           '{constraint}')
+
+    def gen_schema(data: pt.PartData, ver):
+        return gen_simple_schema(data, ver, rule_id, odm_key, cerb_key)
+
+    return init_rule(rule_id, cerb_key, err, gen_schema)
 
 
 def missing_mandatory_column():
@@ -61,6 +80,20 @@ def missing_mandatory_column():
         return schema
 
     return init_rule(rule_id, cerb_rule[0], err, gen_schema)
+
+
+def less_than_min_value():
+    rule_id = less_than_min_value.__name__
+    odm_key = 'minValue'
+    cerb_key = 'min'
+    err = ('Value {value} in row {row_num} in column {column_id} in table '
+           '{table_id} is less than the allowable minimum value of '
+           '{constraint}')
+
+    def gen_schema(data: pt.PartData, ver):
+        return gen_simple_schema(data, ver, rule_id, odm_key, cerb_key)
+
+    return init_rule(rule_id, cerb_key, err, gen_schema)
 
 
 def invalid_category():
@@ -93,6 +126,8 @@ def invalid_category():
 # This is the collection of all validation rules.
 # A tuple is used for immutability.
 ruleset: Tuple[Rule] = (
+    greater_than_max_value(),
     invalid_category(),
+    less_than_min_value(),
     missing_mandatory_column(),
 )

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -32,6 +32,15 @@ class Rule:
     gen_schema: Dict[str, Callable[pt.PartData, Schema]]
 
 
+def init_rule(rule_id, cerb_key, error, gen_schema):
+    return Rule(
+        id=rule_id,
+        key=cerb_key,
+        error_template=error,
+        gen_schema=gen_schema,
+    )
+
+
 def missing_mandatory_column():
     rule_id = missing_mandatory_column.__name__
     cerb_rule = ('required', True)
@@ -51,12 +60,7 @@ def missing_mandatory_column():
                               cerb_rule, table_meta, attr_meta)
         return schema
 
-    return Rule(
-        id=rule_id,
-        key=cerb_rule[0],
-        error_template=err,
-        gen_schema=gen_schema,
-    )
+    return init_rule(rule_id, cerb_rule[0], err, gen_schema)
 
 
 def invalid_category():
@@ -83,12 +87,7 @@ def invalid_category():
                               cerb_rule, table_meta, attr_meta)
         return schema
 
-    return Rule(
-        id=rule_id,
-        key=cerb_rule_key,
-        error_template=err,
-        gen_schema=gen_schema,
-    )
+    return init_rule(rule_id, cerb_rule_key, err, gen_schema)
 
 
 # This is the collection of all validation rules.

--- a/src/odm_validation/schemas.py
+++ b/src/odm_validation/schemas.py
@@ -1,3 +1,6 @@
+from logging import warning
+from typing import Optional
+
 from part_tables import Meta
 from stdext import deep_update
 
@@ -19,29 +22,39 @@ def init_table_schema(table_id, table_meta, attr_schema):
 
 
 def init_attr_schema(attr_id: str, rule_id: str, cerb_rule: tuple,
-                     meta: Meta):
-    return {
-        attr_id: {
-            cerb_rule[0]: cerb_rule[1],
-            'meta': [
-                {
-                    'ruleID': rule_id,
-                    'meta': meta,
-                },
-                # {
-                #     'ruleID': another_rule_using_this_attr,
-                #     'meta': [
-                #         meta_for_attr_used_with_this_rule,
-                #         meta_for_another_attr_used_with_this_rule,
-                #     ]
-                # }
-            ]
-        }
+                     cerb_type: Optional[str], meta: Meta):
+    # ['meta'] is a list with one entry per rule.
+    # ['meta']['meta'] is a `Meta` with one `MetaEntry` per part.
+    inner = {
+        cerb_rule[0]: cerb_rule[1],
+        'meta': [
+            {
+                'ruleID': rule_id,
+                'meta': meta,
+            }
+        ]
     }
+    if cerb_type:
+        inner['type'] = cerb_type
+        inner['coerce'] = cerb_type
+    return {attr_id: inner}
+
+
+def parse_odm_datatype(odm_datatype) -> Optional[str]:
+    """returns the cerberus-equivalent type"""
+    t = odm_datatype
+    if not t:
+        return
+    if t in ['categorical', 'varchar']:
+        return 'string'
+    if t in ['integer', 'float']:
+        return t
+    warning(f'odm datatype {odm_datatype} is not implemented')
 
 
 def update_schema(schema, table_id, attr_id, rule_id, cerb_rule,
                   table_meta: Meta, attr_meta: Meta):
-    attr_schema = init_attr_schema(attr_id, rule_id, cerb_rule, attr_meta)
+    attr_schema = init_attr_schema(attr_id, rule_id, cerb_rule, None,
+                                   attr_meta)
     table_schema = init_table_schema(table_id, table_meta, attr_schema)
     deep_update(table_schema, schema)

--- a/src/odm_validation/stdext.py
+++ b/src/odm_validation/stdext.py
@@ -1,13 +1,17 @@
+import json
 import operator
 from functools import reduce
 from typing import Any, List
 
 
+# TODO: swap src and dst to make the first arg the mutable one
 def deep_update(src: dict, dst: dict):
     """
     Recursively update a dict.
     Subdict's won't be overwritten but also updated.
     List values will be joined, but not recursed.
+
+    Warning: List items may be duplicated.
 
     Originally from: https://stackoverflow.com/a/8310229
     """
@@ -21,6 +25,33 @@ def deep_update(src: dict, dst: dict):
             if len(src_list) > 0:
                 dst_list = dst[key]
                 dst_list += src_list
+
+
+def hash_dict(d) -> str:
+    json.dumps(d, sort_keys=True)
+
+
+def deduplicate_dict_list(dicts: List[dict]) -> List[dict]:
+    assert isinstance(dicts, list)
+    assert len(dicts) == 0 or isinstance(dicts[0], dict)
+    hashes = map(hash_dict, dicts)
+    unique_dict = dict(zip(hashes, dicts))
+    return list(unique_dict.values())
+
+
+def strip_dict_key(d: dict, target_key: str):
+    """Recursively strips `d` of `target_key` entries."""
+    assert isinstance(d, dict)
+    for key, val in list(d.items()):
+        if key == target_key:
+            del d[key]
+        elif isinstance(val, dict):
+            strip_dict_key(val, target_key)
+        elif isinstance(val, list):
+            for item in val:
+                if isinstance(item, dict):
+                    strip_dict_key(item, target_key)
+    return d
 
 
 def flatten(x: List[List[Any]]) -> List[Any]:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+parameterized==0.8.1

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -1,0 +1,132 @@
+import unittest
+# from pprint import pprint
+
+import common
+from cerberusext import ContextualCoercer, OdmValidator
+
+common.unused_import_dummy = 1
+
+column_meta = [
+    {
+        'ruleID': 'myrule1',
+        'meta': [{'a': 'b'}]
+    },
+    {
+        'ruleID': 'myrule2',
+        'meta': [{'c': 'd'}]
+    }
+]
+
+
+schema = {
+    'mytable': {
+        'type': 'list',
+        'schema': {
+            'type': 'dict',
+            'schema': {
+                'amount': {
+                    'type': 'float',
+                    'coerce': 'float',
+                    'meta': column_meta,
+                },
+                'quantity': {
+                    'type': 'integer',
+                    'coerce': 'integer',
+                },
+                'some_missing_field': {
+                }
+            }
+        }
+    }
+}
+
+coercion_schema = {
+    'mytable': {
+        'type': 'list',
+        'schema': {
+            'type': 'dict',
+            'schema': {
+                'amount': {
+                    'check_with': 'float',
+                    'meta': column_meta,
+                },
+                'quantity': {
+                    'check_with': 'integer',
+                }
+            }
+        }
+    }
+}
+
+data = {
+    'mytable': [
+        {'amount': '123', 'unknown': 'asd'},
+        {'quantity': '567'},
+    ]
+}
+
+coerced_data = {
+    'mytable': [
+        {'amount': 123.0, 'unknown': 'asd'},
+        {'quantity': 567},
+    ]
+}
+
+expected_coercion_warnings = [
+    {
+        'coercionRules': ['myrule1', 'myrule2'],
+        'columnName': 'amount',
+        'invalidValue': '123',
+        'message': 'Value 123 in row 1 in column amount in table mytable is '
+                   'a string and was coerced into a number',
+        'row': {'amount': '123', 'unknown': 'asd'},
+        'rowNumber': 1,
+        'tableName': 'mytable',
+        'validationRuleFields': [
+            {'a': 'b'},
+            {'c': 'd'},
+        ],
+        'warningType': '_coercion'
+    },
+    {
+        'coercionRules': [],
+        'columnName': 'quantity',
+        'invalidValue': '567',
+        'message': 'Value 567 in row 2 in column quantity in table mytable is '
+                   'a string and was coerced into a number',
+        'row': {'quantity': '567'},
+        'rowNumber': 2,
+        'tableName': 'mytable',
+        'validationRuleFields': [],
+        'warningType': '_coercion'
+    }
+]
+
+
+class TestCoercion(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_extract_coercion_schema(self):
+        result = ContextualCoercer._extract_coercion_schema(schema)
+        self.assertEqual(result, coercion_schema)
+
+    def test_coerce(self):
+        warnings = []
+        v = ContextualCoercer(warnings=warnings)
+        result = v.coerce(data, schema)
+        self.assertEqual(result, coerced_data)
+        self.assertEqual(warnings, expected_coercion_warnings)
+
+    def test_coerced_type_validation(self):
+        coercion_errors = []
+        coercion_warnings = []
+        v = OdmValidator(coercion_errors=coercion_errors,
+                         coercion_warnings=coercion_warnings)
+        self.assertTrue(v.validate(data, schema))
+        self.assertEqual(coercion_warnings, expected_coercion_warnings)
+        # TODO: self.assertEqual(coercion_errors, expected_coercion_errors)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_min_max_value.py
+++ b/tests/test_min_max_value.py
@@ -1,0 +1,99 @@
+import unittest
+from os.path import join
+# from pprint import pprint
+
+from parameterized import parameterized, parameterized_class
+
+import common
+from utils import (
+    import_dataset,
+    import_json_file,
+    import_schema,
+    import_yaml_file
+)
+from validation import generate_validation_schema, validate_data
+
+
+def _param_range(start, stop):
+    return list(map(lambda i: (i, ), range(start, stop)))
+
+
+class Assets():
+    def __init__(self, ruleId: str):
+        rule_dirname = ruleId.replace('_', '-')
+        asset_dir = join(common.root_dir,
+                         f'assets/validation-rules/{rule_dirname}')
+
+        def asset(filename: str) -> str:
+            return join(asset_dir, filename)
+
+        self.parts_v2 = import_dataset(asset('parts.csv'))
+        self.schemas = {
+            1: import_schema(asset('schema-v1.yml')),
+            2: import_schema(asset('schema-v2.yml')),
+        }
+
+        self.data_pass_v2 = [
+            {'sites': import_dataset(asset('valid-dataset-1.yml'))},
+            {'sites': import_dataset(asset('valid-dataset-2.csv'))},
+            {'sites': import_dataset(asset('valid-dataset-3.yml'))},
+        ]
+
+        self.data_fail_v2 = [
+            {'sites': import_yaml_file(asset('invalid-dataset-1.yml'))},
+            {'sites': import_dataset(asset('invalid-dataset-2.csv'))},
+            {'sites': import_dataset(asset('invalid-dataset-3.csv'))},
+        ]
+
+        self.error_report_fail = [
+            import_json_file(asset('error-report-1.json')),
+            import_json_file(asset('error-report-2.json')),
+            import_json_file(asset('error-report-3.json')),
+        ]
+
+        empty_report = {'errors': [], 'warnings': []}
+        self.error_report_pass = [
+            empty_report,
+            import_json_file(asset('error-report-4.json')),
+            empty_report,
+        ]
+
+
+@parameterized_class([
+   {'ruleId': 'less_than_min_value'},
+   {'ruleId': 'greater_than_max_value'},
+])
+class TestMinMaxValue(unittest.TestCase):
+    ruleId: str
+
+    def setUp(self):
+        self.maxDiff = None
+        self.assets = Assets(self.ruleId)
+
+    @parameterized.expand(_param_range(1, 3))
+    def test_schema_generation(self, major_ver):
+        result = generate_validation_schema(self.assets.parts_v2,
+                                            schema_version=f'{major_ver}.0.0')
+        self.assertDictEqual(self.assets.schemas[major_ver], result)
+
+    def _assertEqual(self, report, expected):
+        self.assertEqual(report.errors, expected['errors'])
+        self.assertEqual(report.warnings, expected['warnings'])
+
+    @parameterized.expand(_param_range(0, 3))
+    def test_passing_datasets(self, ix):
+        report = validate_data(self.assets.schemas[2],
+                               self.assets.data_pass_v2[ix])
+        expected = self.assets.error_report_pass[ix]
+        self._assertEqual(report, expected)
+
+    @parameterized.expand(_param_range(0, 3))
+    def test_failing_datasets(self, ix):
+        report = validate_data(self.assets.schemas[2],
+                               self.assets.data_fail_v2[ix])
+        expected = self.assets.error_report_fail[ix]
+        self._assertEqual(report, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_stdext.py
+++ b/tests/test_stdext.py
@@ -1,0 +1,19 @@
+import unittest
+
+import common
+from stdext import deduplicate_dict_list
+
+common.unused_import_dummy = 1
+
+
+class TestStdExt(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_deduplicate_dict_list(self):
+        d = {'a': 1}
+        self.assertEqual(deduplicate_dict_list([d, d]), [d])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Notable changes**
- assets/validation-rules: fix to fit code.
- docs/validation-rules: use _coercion error/warning type.
- src/
  - cerberusext.py: add validation-subclass for coercion.
  - part_tables.py: add new versions of helper functions with the suffix `2`, as the first step to simplify the code.
  - rules.py: add min/max value rules
  - schemas.py: add type/coercion attributes.