### PR TITLE
docs: ignore generated md files in specs dir

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,6 @@
 # intermediary quarto files
 /examples/**/*.md
+/specs/*.md
 /validation-rules/*.md
 
 # intermediary files from running `quarto preview`


### PR DESCRIPTION
The repo is being polluted by this when generating docs.