### PR TITLE
implement missing_values_found rule

### DIFF
--- a/assets/validation-rules/missing-values-found/error-report-1.json
+++ b/assets/validation-rules/missing-values-found/error-report-1.json
@@ -9,9 +9,11 @@
                 "siteID": "1",
                 "geoLat": ""
             },
+            "invalidValue": "",
             "validationRuleFields": [
                 {
                     "partID": "geoLat",
+                    "sites": "header",
                     "sitesRequired": "mandatory"
                 }
             ],

--- a/assets/validation-rules/missing-values-found/error-report-2.json
+++ b/assets/validation-rules/missing-values-found/error-report-2.json
@@ -4,6 +4,7 @@
             "warningType": "missing_values_found",
             "tableName": "sites",
             "columnName": "geoLat",
+            "invalidValue": "  ",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
@@ -12,6 +13,7 @@
             "validationRuleFields": [
                 {
                     "partID": "geoLat",
+                    "sites": "header",
                     "sitesRequired": "mandatory"
                 }
             ],

--- a/assets/validation-rules/missing-values-found/error-report-3.json
+++ b/assets/validation-rules/missing-values-found/error-report-3.json
@@ -4,6 +4,7 @@
             "warningType": "missing_values_found",
             "tableName": "sites",
             "columnName": "geoLat",
+            "invalidValue": "NA",
             "rowNumber": 1,
             "row": {
                 "siteID": "1",
@@ -12,6 +13,7 @@
             "validationRuleFields": [
                 {
                     "partID": "geoLat",
+                    "sites": "header",
                     "sitesRequired": "mandatory"
                 }
             ],

--- a/assets/validation-rules/missing-values-found/parts.csv
+++ b/assets/validation-rules/missing-values-found/parts.csv
@@ -1,6 +1,7 @@
 partID,partType,firstReleased,status,sites,sitesRequired,version1Location,version1Table,version1Variable
 NA,missingness,2.0,active,NA,NA,NA,NA,NA
+null,missingness,1.0,active,NA,NA,NA,NA,NA
 NA_missing,missingness,1.0,active,NA,NA,NA,NA,NA
-sites,table,1.0,active,NA,NA,tables,sites,NA
+sites,table,1.0,active,NA,NA,tables,Site,NA
 geoLat,attribute,1.0,active,header,mandatory,variables,Site,latitude
 geoLong,attribute,1.0,active,header,optional,variables,Site,longitude

--- a/assets/validation-rules/missing-values-found/schema-v1.yml
+++ b/assets/validation-rules/missing-values-found/schema-v1.yml
@@ -6,21 +6,21 @@ schema:
       type: dict
       schema:
         latitude:
-          trimEmpty: true
+          emptyTrimmed: false
           forbidden:
           - NA_missing
+          - 'null'
           meta:
-          - ruleId: missing_values_found
+          - ruleID: missing_values_found
             meta:
-            - partID: NA_missing
-              partType: missingness
             - partID: geoLat
+              sites: header
               sitesRequired: mandatory
               version1Location: variables
               version1Table: Site
               version1Variable: latitude
-    meta:
-      - partID: sites
-        partType: table
-        version1Location: tables
-        version1Table: Site 
+      meta:
+        - partID: sites
+          partType: table
+          version1Location: tables
+          version1Table: Site

--- a/assets/validation-rules/missing-values-found/schema-v2.yml
+++ b/assets/validation-rules/missing-values-found/schema-v2.yml
@@ -6,16 +6,17 @@ schema:
       type: dict
       schema:
         geoLat:
-          trimEmpty: true
+          emptyTrimmed: false
           forbidden:
           - NA
+          - NA_missing
+          - 'null'
           meta:
-          - ruleId: missing_values_found
+          - ruleID: missing_values_found
             meta:
-            - partID: NA
-              partType: missingness
             - partID: geoLat
+              sites: header
               sitesRequired: mandatory
-    meta:
+      meta:
       - partID: sites
         partType: table

--- a/docs/validation-rules/missing_values_found.qmd
+++ b/docs/validation-rules/missing_values_found.qmd
@@ -44,6 +44,7 @@ A value that is invalid due to this rule should generate a **warning** and **not
 * **warningType**: missing_values_found
 * **tableName**: The name of the table containing the missing values
 * **columnName**: The name of the mandatory column containing the missing values
+* **invalidValue**: The invalid value
 * **rowNumber**: The index of the table row with the error
 * **row**: The dictionary containing the row
 * **validationRuleFields**: The ODM data dictionary rows used to generate this rule
@@ -98,7 +99,7 @@ we would add this rule only to the `geoLat` column in the `sites` table. This ru
 We will need to use two rules from cerberus for this validation rule:
 
 1. A [forbidden](https://docs.python-cerberus.org/en/stable/validation-rules.html#forbidden) rule which includes all the `missingness` values from the dictionary
-2. A custom rule called `trimEmpty` for empty values which also handles trimming. Although the cerberus library has an `empty` rule, the rule allows values that are "empty" once trimmed.
+2. A custom rule called `emptyTrimmed` for empty values which also handles trimming. Although the cerberus library has an `empty` rule, the rule allows values that are "empty" once trimmed.
 
 The cerberus schema for the ODM dictionary snippet above is shown below,
 

--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 # from pprint import pprint
 
 from cerberus import Validator
+from cerberus.errors import ErrorDefinition
 
 import part_tables as pt
 import rules as validation_rules
@@ -35,6 +36,9 @@ class CoercionCtx:
     row_num: str
     table: str
     value: str
+
+
+EMPTY_TRIMMED_RULE = 0x101
 
 
 def _get_meta_rule_ids(column_meta) -> List[str]:
@@ -245,6 +249,16 @@ class OdmValidator(Validator):
         self.allow_unknown = True
         self.unique_state = self._config['unique_state']
         self.error_state = self._config['error_state']
+
+    def _validate_emptyTrimmed(self, constraint, field, raw_value):
+        """{'type': 'boolean'}"""
+        expect_empty = constraint
+        is_str = isinstance(raw_value, str)
+        value = raw_value.strip() if is_str else raw_value
+        is_empty = not value or (is_str and value == '')
+        if is_empty != expect_empty:
+            err = ErrorDefinition(EMPTY_TRIMMED_RULE, 'emptyTrimmed')
+            self._error(field, err)
 
     def _validate_unique(self, constraint, field, value):
         """{'type': 'boolean'}"""

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -267,12 +267,21 @@ def get_table_id(part: dict) -> Optional[str]:
     warning(f'part {get_partID(part)} does not belong to any table')
 
 
+def _not_empty(field):
+    _, val = field
+    return val not in NA
+
+
 def strip(parts: Dataset):
     # TODO: strip version1* fields when not version 1
-    """Removes NA fields."""
+    """Removes NA fields, except from partID."""
     result = []
     for sparse_row in parts:
-        row = {k: v for k, v in sparse_row.items() if v not in NA}
+        fields = iter(sparse_row.items())
+        part_id_pair = next(fields)
+        assert part_id_pair[0] == PART_ID, 'partID must be the first column'
+        row = {k: v for k, v in filter(_not_empty, fields)}
+        row[PART_ID] = part_id_pair[1]
         result.append(row)
     return result
 

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -309,13 +309,13 @@ def partmap(parts) -> PartMap:
     return {get_partID(part): part for part in parts}
 
 
-def gen_partdata(parts_v2: Dataset, version: Version):
-    tables = list(filter(is_table, parts_v2))
+def gen_partdata(parts: Dataset, version: Version):
+    tables = list(filter(is_table, parts))
     table_ids = list(map(get_partID, tables))
-    attributes = list(filter(is_attr, parts_v2))
-    categories = list(filter(is_cat, parts_v2))
-    catsets = partmap(filter(is_catset_attr, parts_v2))
-    bool_set = tuple(map(get_partID, islice(filter(is_bool_set, parts_v2), 2)))
+    attributes = list(filter(is_attr, parts))
+    categories = list(filter(is_cat, parts))
+    catsets = partmap(filter(is_catset_attr, parts))
+    bool_set = tuple(map(get_partID, islice(filter(is_bool_set, parts), 2)))
 
     table_attrs = defaultdict(list)
     for attr in attributes:
@@ -344,7 +344,7 @@ def gen_partdata(parts_v2: Dataset, version: Version):
             table_ids=cs_table_ids,
         )
 
-    mappings = {get_partID(p): get_mappings(p, version) for p in parts_v2}
+    mappings = {get_partID(p): get_mappings(p, version) for p in parts}
     assert None not in mappings
 
     return PartData(

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -324,6 +324,14 @@ def partmap(parts) -> PartMap:
     return {get_partID(part): part for part in parts}
 
 
+def map_ids(mappings: Dict[PartId, PartId], part_ids: List[PartId],
+            ver: Version) -> List[PartId]:
+    if ver.major == 1:
+        return flatten([mappings[id] for id in part_ids])
+    else:
+        return part_ids
+
+
 def gen_partdata(parts: Dataset, version: Version):
     tables = list(filter(is_table, parts))
     table_ids = list(map(get_partID, tables))

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -338,7 +338,7 @@ def gen_partdata(parts: Dataset, version: Version):
     attributes = list(filter(is_attr, parts))
     categories = list(filter(is_cat, parts))
     catsets = partmap(filter(is_catset_attr, parts))
-    bool_set = tuple(map(get_partID, islice(filter(is_bool_set, parts), 2)))
+    bool_set0 = tuple(map(get_partID, islice(filter(is_bool_set, parts), 2)))
     null_set = set(map(get_partID, filter(is_null_set, parts)))
 
     table_attrs = defaultdict(list)
@@ -371,8 +371,11 @@ def gen_partdata(parts: Dataset, version: Version):
     mappings = {get_partID(p): get_mappings(p, version) for p in parts}
     assert None not in mappings
 
+    bool_set1 = set(map_ids(mappings, list(bool_set0), version))
+
+    # TODO: preserve unmapped version of bool_set for bool meta fields
     return PartData(
-        bool_set=bool_set,
+        bool_set=bool_set1,
         null_set=null_set,
         table_data=table_data,
         catset_data=catset_data,

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -26,6 +26,7 @@ MetaMap = DefaultDict[PartId, Meta]
 # type aliases (other)
 Dataset = List[Row]
 PartMap = Dict[PartId, Part]
+TableId = PartId
 
 
 class MapKind(Enum):

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -64,6 +64,7 @@ class PartData:
     The parts-list is stripped of empty values before generating this.
     """
     bool_set: BoolSet
+    null_set: Set[str]
     catset_data: Dict[PartId, CatsetData]  # category-set data, by catset id
     table_data: Dict[PartId, TableData]  # table data, by table id
     mappings: Dict[PartId, List[PartId]]  # v1 mapping, by part id
@@ -99,6 +100,7 @@ BOOLEAN = 'boolean'
 BOOLEAN_SET = 'booleanSet'
 DATETIME = 'datetime'
 MANDATORY = 'mandatory'
+MISSINGNESS = 'missingness'
 PART_NULL_SET = {'', 'NA', 'Not applicable', 'null'}
 
 V1_VARIABLE = 'version1Variable'
@@ -192,6 +194,11 @@ def has_catset(p):
 
 def is_bool_set(part):
     return part.get(CATSET_ID) == BOOLEAN_SET
+
+
+def is_null_set(part):
+    # the ODM doesn't have these values as a catset, but it's a set
+    return part.get(PART_TYPE) == MISSINGNESS
 
 
 def is_table(p):
@@ -317,6 +324,7 @@ def gen_partdata(parts: Dataset, version: Version):
     categories = list(filter(is_cat, parts))
     catsets = partmap(filter(is_catset_attr, parts))
     bool_set = tuple(map(get_partID, islice(filter(is_bool_set, parts), 2)))
+    null_set = set(map(get_partID, filter(is_null_set, parts)))
 
     table_attrs = defaultdict(list)
     for attr in attributes:
@@ -350,6 +358,7 @@ def gen_partdata(parts: Dataset, version: Version):
 
     return PartData(
         bool_set=bool_set,
+        null_set=null_set,
         table_data=table_data,
         catset_data=catset_data,
         mappings=mappings,

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -83,6 +83,7 @@ CATSET_ID = 'catSetID'
 DATA_TYPE = 'dataType'
 PART_ID = 'partID'
 PART_TYPE = 'partType'
+STATUS = 'status'
 
 PART_ID_ORIGINAL = 'partID_original'
 TABLE_ID_ORIGINAL = 'tableID_original'
@@ -97,6 +98,7 @@ CATEGORY = 'category'
 TABLE = 'table'
 
 # other value constants
+ACTIVE = 'active'
 BOOLEAN = 'boolean'
 BOOLEAN_SET = 'booleanSet'
 DATETIME = 'datetime'
@@ -305,7 +307,7 @@ def filter_compatible(parts: Dataset, schema_version: Version) -> Dataset:
     for row in parts:
         part_id = get_partID(row)
         first, last = get_version_range(row)
-        active: bool = row.get('status') == 'active'
+        active: bool = row.get(STATUS) == ACTIVE
         if not (is_compatible(active, first, last, schema_version)):
             warning(f'skipping incompatible part: {part_id}')
             continue

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -99,7 +99,7 @@ BOOLEAN = 'boolean'
 BOOLEAN_SET = 'booleanSet'
 DATETIME = 'datetime'
 MANDATORY = 'mandatory'
-NA = {'', 'NA', 'Not applicable', 'null'}
+PART_NULL_SET = {'', 'NA', 'Not applicable', 'null'}
 
 V1_VARIABLE = 'version1Variable'
 V1_LOCATION = 'version1Location'
@@ -269,12 +269,13 @@ def get_table_id(part: dict) -> Optional[str]:
 
 def _not_empty(field):
     _, val = field
-    return val not in NA
+    return val not in PART_NULL_SET
 
 
 def strip(parts: Dataset):
-    # TODO: strip version1* fields when not version 1
-    """Removes NA fields, except from partID."""
+    """Removes null fields, except from partID."""
+    # 'partID' may be defining null fields for data, so we can't strip those.
+    # TODO: Strip version1* fields when not version 1.
     result = []
     for sparse_row in parts:
         fields = iter(sparse_row.items())

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional
 from logging import warning
+from typing import Dict, List, Optional, Set
 # from pprint import pprint
 
 import part_tables as pt
@@ -17,10 +17,12 @@ class OdmValueCtx:
     value: str
     datatype: str
     bool_set: pt.BoolSet
+    null_set: Set[str]
 
     @staticmethod
     def default():
-        return OdmValueCtx(value=None, datatype=None, bool_set=None)
+        return OdmValueCtx(value=None, datatype=None, bool_set=None,
+                           null_set={})
 
 
 def get_table_meta(table: Part, version: Version) -> Meta:

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -192,6 +192,7 @@ def gen_value_schema(data: pt.PartData, ver: Version, rule_id: str,
 
 
 def is_mandatory(table_id: pt.TableId, attr: Part):
+    # Checks whether an attribute is mandatory in a table
     req_key = pt.table_required_field(table_id)
     req_val = attr.get(req_key)
     return req_val == pt.MANDATORY
@@ -199,6 +200,10 @@ def is_mandatory(table_id: pt.TableId, attr: Part):
 
 def gen_conditional_schema(data: pt.PartData, ver: Version, rule_id: str,
                            gen_cerb_rules, pred: AttrPredicate):
+    # Helper function to generate a cerberus schema the implements an ODM
+    # validation rule
+    # Uses the passed pred argument to decide whether an entry should be
+    # created for an attribute in a table
     schema = {}
     odm_key = None
     for table in table_items2(data):

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Set
 import part_tables as pt
 from part_tables import Meta, MetaEntry, Part, PartData, PartId
 from schemas import init_attr_schema, init_table_schema
-from stdext import deep_update, flatten
+from stdext import deep_update
 from versions import Version
 
 
@@ -57,14 +57,6 @@ def get_catset_meta(table_id: PartId, catset: Part, categories: List[Part],
     for cat in categories:
         meta.append({k: cat[k] for k in cat_keys})
     return meta
-
-
-def map_ids(mappings: Dict[PartId, PartId], part_ids: List[PartId],
-            ver: Version) -> List[PartId]:
-    if ver.major == 1:
-        return flatten([mappings[id] for id in part_ids])
-    else:
-        return part_ids
 
 
 def get_part_ids(parts: List[Part]) -> List[PartId]:

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -134,6 +134,26 @@ def missing_mandatory_column():
     return init_rule(rule_id, err, gen_cerb_rules, gen_schema)
 
 
+def missing_values_found():
+    # TODO: rename to missing_mandatory_value?
+    rule_id = missing_values_found.__name__
+    err = ('Mandatory column {column_id} in table {table_id} has a missing '
+           'value in row {row_num}')
+
+    def gen_cerb_rules(val_ctx: OdmValueCtx):
+        return {
+            'emptyTrimmed': False,
+            'forbidden': sorted(val_ctx.null_set),
+        }
+
+    def gen_schema(data: pt.PartData, ver):
+        return gen_conditional_schema(data, ver, rule_id, gen_cerb_rules,
+                                      is_mandatory)
+
+    return init_rule(rule_id, err, gen_cerb_rules, gen_schema,
+                     is_warning=True, match_all_keys=True)
+
+
 def less_than_min_length():
     rule_id = less_than_min_length.__name__
     odm_key = 'minLength'
@@ -245,4 +265,5 @@ ruleset: Tuple[Rule] = (
     less_than_min_length(),
     less_than_min_value(),
     missing_mandatory_column(),
+    missing_values_found(),
 )

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -21,7 +21,6 @@ from rule_primitives import (
     get_attr_meta,
     get_catset_meta,
     get_table_meta,
-    map_ids,
     table_items,
 )
 from versions import Version
@@ -194,7 +193,7 @@ def invalid_category():
                 cs = cs_data.part
                 categories = cs_data.cat_parts
                 cat_ids0 = list(map(pt.get_partID, categories))
-                cat_ids1 = map_ids(data.mappings, cat_ids0, ver)
+                cat_ids1 = pt.map_ids(data.mappings, cat_ids0, ver)
                 cerb_rule = (cerb_rule_key, cat_ids1)
                 attr_meta = get_catset_meta(table_id0, cs, categories, ver)
                 update_schema(schema, table_id1, attr_id1, rule_id,

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -4,7 +4,7 @@ Rule functions are ordered alphabetically.
 """
 
 from dataclasses import dataclass
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, List, Tuple
 
 import part_tables as pt
 from schemas import Schema, update_schema
@@ -45,13 +45,15 @@ class Rule:
     - value_type
     """
     id: str
-    key: str
+    keys: List[str]
     is_warning: bool
+    match_all_keys: bool
     gen_schema: Callable[pt.PartData, Schema]
     get_error_template: Callable[[Any, str], str]
 
 
-def init_rule(rule_id, error, gen_cerb_rules, gen_schema, is_warning=False):
+def init_rule(rule_id, error, gen_cerb_rules, gen_schema,
+              is_warning=False, match_all_keys=False):
     """
     - `error` can either be a string or a function taking a value and returning
       a string.
@@ -62,8 +64,9 @@ def init_rule(rule_id, error, gen_cerb_rules, gen_schema, is_warning=False):
     cerb_keys = list(gen_cerb_rules(OdmValueCtx.default()).keys())
     return Rule(
         id=rule_id,
-        key=cerb_keys[0],
+        keys=cerb_keys,
         is_warning=is_warning,
+        match_all_keys=match_all_keys,
         get_error_template=get_error_template,
         gen_schema=gen_schema,
     )

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -46,11 +46,12 @@ class Rule:
     """
     id: str
     key: str
+    is_warning: bool
     gen_schema: Callable[pt.PartData, Schema]
     get_error_template: Callable[[Any, str], str]
 
 
-def init_rule(rule_id, error, gen_cerb_rules, gen_schema):
+def init_rule(rule_id, error, gen_cerb_rules, gen_schema, is_warning=False):
     """
     - `error` can either be a string or a function taking a value and returning
       a string.
@@ -62,6 +63,7 @@ def init_rule(rule_id, error, gen_cerb_rules, gen_schema):
     return Rule(
         id=rule_id,
         key=cerb_keys[0],
+        is_warning=is_warning,
         get_error_template=get_error_template,
         gen_schema=gen_schema,
     )

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -47,9 +47,18 @@ class Rule:
     id: str
     keys: List[str]
     is_warning: bool
-    match_all_keys: bool
     gen_schema: Callable[pt.PartData, Schema]
     get_error_template: Callable[[Any, str], str]
+
+    match_all_keys: bool
+    """Used when mapping a Cerberus error to its ODM validation rule. It
+    decides whether all the Cerberus keys that are part of this rule can be
+    mapped to an odm validation rule or just the first one. For example, The
+    less_than_min_value rule requires three Cerberus rules for its
+    implementation: min, type and coerce. However, only the first one should be
+    mapped to an min-value error. The missing_values_found rule requires two
+    Cerberus rules for its implementation: emptyTrimmed and forbidden. Both of
+    these should be mapped to a missing_values_found error."""
 
 
 def init_rule(rule_id, error, gen_cerb_rules, gen_schema,

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -31,7 +31,7 @@ from stdext import (
 from versions import __version__, parse_version
 
 
-@dataclass
+@dataclass(frozen=True)
 class ErrorContext:
     allowed_values: Set[str]
     column_id: str

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -151,7 +151,7 @@ def _gen_rule_error(ctx: ErrorContext):
         error['row'] = ctx.rows[0]
 
     # value
-    if ctx.value:
+    if ctx.value is not None:
         error['invalidValue'] = ctx.value
 
     return error

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -76,6 +76,10 @@ def _get_latest_odm_version() -> str:
 
 
 def _gen_cerb_rule_map():
+    # Generates a dictionary that maps a cerberus validation rule to the ODM
+    # rule that uses it.
+    # Assumes that each cerberus validation can be mapped to one ODM validation
+    # rule with no repetations.
     result = {}
     for r in ruleset:
         for key in r.keys:

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -75,11 +75,22 @@ def _get_latest_odm_version() -> str:
     return versions[-1]
 
 
+def _gen_cerb_rule_map():
+    result = {}
+    for r in ruleset:
+        for key in r.keys:
+            assert key not in result
+            result[key] = r
+            if not r.match_all_keys:
+                break
+    return result
+
+
 # public constants
 ODM_LATEST = _get_latest_odm_version()
 
 # private constants
-_KEY_RULES = {r.key: r for r in ruleset}
+_KEY_RULES = _gen_cerb_rule_map()
 
 
 def _prettify_rule_name(rule: Rule):
@@ -162,7 +173,8 @@ def _transform_rule(rule: Rule, column_meta) -> Rule:
     """Returns a new rule, depending on `column_meta`. Currently only returns
     invalid_type if rule-key is 'allowed' and dataType is bool."""
     # XXX: dependency on meta value (which is only supposed to aid debug)
-    if rule.key == 'allowed':
+    # XXX: does not handle rules with match_all_keys enabled
+    if rule.keys[0] == 'allowed':
         rule_ids = list(map(_get_ruleId, column_meta))
         new_rule = next(filter(_is_invalid_type_rule, ruleset), None)
         if not new_rule or new_rule.id not in rule_ids:

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,6 +22,10 @@ class OdmTestCase(unittest.TestCase):
         with self.assertNoLogs(None, 'ERROR'):
             super().run(result)
 
+    def assertReportEqual(self, expected, report):
+        self.assertEqual(expected['errors'], report.errors)
+        self.assertEqual(expected['warnings'], report.warnings)
+
 
 def setup_import_path():
     global __package__

--- a/tests/test_duplicate_entries_found.py
+++ b/tests/test_duplicate_entries_found.py
@@ -58,10 +58,6 @@ class TestDuplicateEntriesFound(common.OdmTestCase):
                                             schema_version=f'{major_ver}.0.0')
         self.assertDictEqual(self.assets.schemas[major_ver], result)
 
-    def _assertEqual(self, expected, report):
-        self.assertEqual(expected['errors'], report.errors)
-        self.assertEqual(expected['warnings'], report.warnings)
-
     def test_passing_datasets(self):
         report = _validate_data_ext(self.assets.schemas[2],
                                     self.assets.data_pass)
@@ -72,7 +68,7 @@ class TestDuplicateEntriesFound(common.OdmTestCase):
         report = _validate_data_ext(schema=self.assets.schemas[2],
                                     data=self.assets.data_fail[i])
         expected = self.assets.error_report[i]
-        self._assertEqual(expected, report)
+        self.assertReportEqual(expected, report)
 
 
 if __name__ == '__main__':

--- a/tests/test_invalid_type.py
+++ b/tests/test_invalid_type.py
@@ -75,10 +75,6 @@ class TestInvalidType(common.OdmTestCase):
                                                  rule_whitelist=self.whitelist)
         self.assertDictEqual(self.assets.schemas[major_ver], result)
 
-    def _assertEqual(self, expected, report):
-        self.assertEqual(expected['errors'], report.errors)
-        self.assertEqual(expected['warnings'], report.warnings)
-
     @parameterized.expand(param_range(0, 2))
     def test_passing_datasets(self, i):
         if i < len(self.assets.data_pass):
@@ -92,7 +88,7 @@ class TestInvalidType(common.OdmTestCase):
             report = _validate_data_ext(schema=self.assets.schemas[2],
                                         data=self.assets.data_fail[i])
             expected = self.assets.error_report[i]
-            self._assertEqual(expected, report)
+            self.assertReportEqual(expected, report)
 
 
 if __name__ == '__main__':

--- a/tests/test_min_max_length.py
+++ b/tests/test_min_max_length.py
@@ -58,10 +58,6 @@ class TestMinMaxLength(common.OdmTestCase):
             rule_whitelist=self.whitelist)
         self.assertDictEqual(self.assets.schemas[major_ver], result)
 
-    def _assertEqual(self, expected, report):
-        self.assertEqual(expected['errors'], report.errors)
-        self.assertEqual(expected['warnings'], report.warnings)
-
     def test_pass(self):
         report = validate_data(self.assets.schemas[2],
                                self.assets.data_pass_v2)
@@ -70,7 +66,7 @@ class TestMinMaxLength(common.OdmTestCase):
     def test_fail(self):
         report = validate_data(self.assets.schemas[2],
                                self.assets.data_fail_v2)
-        self._assertEqual(self.assets.error_report, report)
+        self.assertReportEqual(self.assets.error_report, report)
 
 
 if __name__ == '__main__':

--- a/tests/test_min_max_value.py
+++ b/tests/test_min_max_value.py
@@ -74,17 +74,13 @@ class TestMinMaxValue(common.OdmTestCase):
             rule_whitelist=[self.ruleId])
         self.assertDictEqual(self.assets.schemas[major_ver], result)
 
-    def _assertEqual(self, expected, report):
-        self.assertEqual(expected['errors'], report.errors)
-        self.assertEqual(expected['warnings'], report.warnings)
-
     @parameterized.expand(param_range(0, 3))
     def test_passing_datasets(self, ix):
         report = _validate_data_ext(self.assets.schemas[2],
                                     self.assets.data_pass_v2[ix],
                                     rule_whitelist=self.whitelist)
         expected = self.assets.error_report_pass[ix]
-        self._assertEqual(expected, report)
+        self.assertReportEqual(expected, report)
 
     @parameterized.expand(param_range(0, 3))
     def test_failing_datasets(self, ix):
@@ -92,7 +88,7 @@ class TestMinMaxValue(common.OdmTestCase):
                                     self.assets.data_fail_v2[ix],
                                     rule_whitelist=self.whitelist)
         expected = self.assets.error_report_fail[ix]
-        self._assertEqual(expected, report)
+        self.assertReportEqual(expected, report)
 
 
 if __name__ == '__main__':

--- a/tests/test_missing_values_found.py
+++ b/tests/test_missing_values_found.py
@@ -1,0 +1,73 @@
+import unittest
+from os.path import join
+# from pprint import pprint
+
+from parameterized import parameterized
+
+import common
+from common import asset, root_dir, param_range
+from utils import (
+    import_dataset,
+    import_schema,
+)
+from validation import _generate_validation_schema_ext, _validate_data_ext
+
+
+class Assets():
+    def __init__(self, rule_id: str, table: str):
+        rule_dirname = rule_id.replace('_', '-')
+        common.ASSET_DIR = join(root_dir,
+                                f'assets/validation-rules/{rule_dirname}')
+
+        # parts
+        self.parts = import_dataset(asset('parts.csv'))
+
+        # schemas
+        self.schemas = {
+            1: import_schema(asset('schema-v1.yml')),
+            2: import_schema(asset('schema-v2.yml')),
+        }
+
+        # datasets and error reports
+        self.data_pass = {table: import_dataset(asset('valid-dataset.*'))}
+        self.data_fail = {}
+        self.reports = {}
+        for i in range(1, 4):
+            self.data_fail[i] = \
+                {table: import_dataset(asset(f'invalid-dataset-{i}.*'))}
+            self.reports[i] = import_dataset(asset(f'error-report-{i}.json'))
+
+
+class TestMissingValuesFound(common.OdmTestCase):
+    rule_id = 'missing_values_found'
+    table = 'sites'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+        cls.assets = Assets(cls.rule_id, cls.table)
+        cls.whitelist = [cls.rule_id]
+
+    @parameterized.expand(param_range(1, 3))
+    def test_schema_generation(self, major_ver):
+        ver = f'{major_ver}.0.0'
+        result = _generate_validation_schema_ext(parts=self.assets.parts,
+                                                 schema_version=ver,
+                                                 rule_whitelist=self.whitelist)
+        self.assertDictEqual(self.assets.schemas[major_ver], result)
+
+    def test_passing_datasets(self):
+        report = _validate_data_ext(self.assets.schemas[2],
+                                    self.assets.data_pass)
+        self.assertTrue(report.valid())
+
+    @parameterized.expand(param_range(1, 4))
+    def test_failing_datasets(self, i):
+        report = _validate_data_ext(schema=self.assets.schemas[2],
+                                    data=self.assets.data_fail[i])
+        expected = self.assets.reports[i]
+        self.assertReportEqual(expected, report)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1,7 +1,8 @@
 import unittest
 
 import common
-from part_tables import get_mappings, is_compatible
+import part_tables as pt
+from part_tables import get_mappings
 from versions import Version, parse_version
 
 common.unused_import_dummy = 1
@@ -15,22 +16,28 @@ def get_row(first: str, last: str, active: bool):
     }
 
 
+def part_is_compatible(part: pt.Part, version: Version) -> bool:
+    first, last = pt.get_version_range(part)
+    active: bool = part.get('status') == 'active'
+    return pt.is_compatible(active, first, last, version)
+
+
 class TestVersionCompat(common.OdmTestCase):
     def test_same(self):
         row = get_row('1.0.0', '1.0.0', True)
-        self.assertTrue(is_compatible(row, parse_version('1.0.0')))
+        self.assertTrue(part_is_compatible(row, parse_version('1.0.0')))
 
     def test_eq_first(self):
         row = get_row('1.0.0', '2.0.0', False)
-        self.assertTrue(is_compatible(row, parse_version('1.0.0')))
+        self.assertTrue(part_is_compatible(row, parse_version('1.0.0')))
 
     def test_eq_last(self):
         row = get_row('1.0.0', '2.0.0', False)
-        self.assertFalse(is_compatible(row, parse_version('2.0.0')))
+        self.assertFalse(part_is_compatible(row, parse_version('2.0.0')))
 
     def test_incomplete(self):
         row = get_row('2', '2.0', True)
-        self.assertTrue(is_compatible(row, parse_version('2.0.')))
+        self.assertTrue(part_is_compatible(row, parse_version('2.0.')))
 
 
 class TestVersion1FieldsExist(common.OdmTestCase):

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -12,13 +12,13 @@ def get_row(first: str, last: str, active: bool):
     return {
         'firstReleased': first,
         'lastUpdated': last,
-        'status': 'active' if active else 'depreciated',
+        pt.STATUS: pt.ACTIVE if active else 'depreciated',
     }
 
 
 def part_is_compatible(part: pt.Part, version: Version) -> bool:
     first, last = pt.get_version_range(part)
-    active: bool = part.get('status') == 'active'
+    active: bool = part.get(pt.STATUS) == pt.ACTIVE
     return pt.is_compatible(active, first, last, version)
 
 


### PR DESCRIPTION
fixes #39 

- rename custom cerb rule trimEmpty to emptyTrimmed
- change emptyTrimmed value to False to match existing empty rule semantics
- add functionality for reporting warnings from rules
- add functionality for matching multiple keys to one rule
- add "gen_conditional_schema" helper