### PR TITLE
add datetime to min/max-value rules

### DIFF
--- a/assets/validation-rules/greater-than-max-value/error-report-pass-2.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-pass-2.json
@@ -1,0 +1,47 @@
+{
+    "errors": [],
+    "warnings": [
+        {
+            "warningType": "_coercion",
+	    "coercionRules": ["greater_than_max_value"],
+            "tableName": "sites",
+            "columnName": "geoLat",
+            "rowNumber": 1,
+            "row": {
+                "siteID": "1",
+                "geoLat": "89",
+                "geoLong": "90.1"
+            },
+            "invalidValue": "89",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "maxValue": "90",
+                    "sites": "header"
+                }
+            ],
+            "message": "Value 89 in row 1 in column geoLat in table sites is a string and was coerced into a number"
+        },
+        {
+            "warningType": "_coercion",
+	    "coercionRules": ["greater_than_max_value"],
+            "tableName": "sites",
+            "columnName": "geoLong",
+            "rowNumber": 1,
+            "row": {
+                "siteID": "1",
+                "geoLat": "89",
+                "geoLong": "90.1"
+            },
+            "invalidValue": "90.1",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "maxValue": "90.15",
+                    "sites": "header"
+                }
+            ],
+            "message": "Value 90.1 in row 1 in column geoLong in table sites is a string and was coerced into a number"
+        }
+    ]
+}

--- a/assets/validation-rules/greater-than-max-value/error-report-pass-4.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-pass-4.json
@@ -1,25 +1,5 @@
 {
-    "errors": [
-        {
-            "errorType": "greater_than_max_value",
-            "tableName": "sites",
-            "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
-                "siteID": 1,
-                "lastEdited": "2024-12-30 00:00:00"
-            },
-            "invalidValue": "2024-12-30 00:00:00",
-            "validationRuleFields": [
-                {
-                    "partID": "lastEdited",
-                    "maxValue": "2024-01-01",
-                    "sites": "header"
-                }
-            ],
-            "message": "Value 2024-12-30 00:00:00 in row 1 in column lastEdited in table sites is greater than the allowable maximum value of 2024-01-01 00:00:00"
-        }
-    ],
+    "errors": [],
     "warnings": [
         {
             "warningType": "_coercion",
@@ -28,10 +8,10 @@
             "columnName": "lastEdited",
             "rowNumber": 1,
             "row": {
-                "lastEdited": "2024-12-30",
-                "siteID": 1
+                "siteID": 1,
+                "lastEdited": "2023-01-30"
             },
-            "invalidValue": "2024-12-30",
+            "invalidValue": "2023-01-30",
             "validationRuleFields": [
                 {
                     "partID": "lastEdited",
@@ -39,7 +19,27 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2024-12-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "Value 2023-01-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+        },
+        {
+            "warningType": "_coercion",
+            "coercionRules": ["greater_than_max_value"],
+            "tableName": "sites",
+            "columnName": "lastEdited",
+            "rowNumber": 2,
+            "row": {
+                "siteID": 2,
+                "lastEdited": "2023-01-30T00:00:00"
+            },
+            "invalidValue": "2023-01-30T00:00:00",
+            "validationRuleFields": [
+                {
+                    "partID": "lastEdited",
+                    "maxValue": "2024-01-01",
+                    "sites": "header"
+                }
+            ],
+            "message": "Value 2023-01-30T00:00:00 in row 2 in column lastEdited in table sites is a string and was coerced into a datetime"
         }
     ]
 }

--- a/assets/validation-rules/greater-than-max-value/invalid-dataset-4.yml
+++ b/assets/validation-rules/greater-than-max-value/invalid-dataset-4.yml
@@ -1,0 +1,2 @@
+- siteID: 1
+  lastEdited: "2024-12-30"

--- a/assets/validation-rules/greater-than-max-value/parts-datetime.csv
+++ b/assets/validation-rules/greater-than-max-value/parts-datetime.csv
@@ -1,0 +1,2 @@
+partID,partType,sites,dataType,maxValue,version1Location,version1Table,version1Variable,status
+lastEdited,attribute,header,datetime,2024-01-01,variables,NA,LastEdited,active

--- a/assets/validation-rules/greater-than-max-value/schema-datetime-v1.yml
+++ b/assets/validation-rules/greater-than-max-value/schema-datetime-v1.yml
@@ -1,0 +1,24 @@
+schemaVersion: 1.0.0
+schema:
+  Site:
+    type: list
+    schema:
+      type: dict
+      schema:
+        LastEdited:
+          type: datetime
+          coerce: datetime
+          max: 2024-01-01 00:00:00
+          meta:
+          - ruleID: greater_than_max_value
+            meta:
+            - partID: lastEdited
+              maxValue: "2024-01-01"
+              sites: header
+              version1Location: variables
+              version1Variable: LastEdited
+      meta:
+        - partID: sites
+          partType: table
+          version1Location: tables
+          version1Table: Site

--- a/assets/validation-rules/greater-than-max-value/schema-datetime-v2.yml
+++ b/assets/validation-rules/greater-than-max-value/schema-datetime-v2.yml
@@ -1,0 +1,20 @@
+schemaVersion: 2.0.0
+schema:
+  sites:
+    type: list
+    schema:
+      type: dict
+      schema:
+        lastEdited:
+          type: datetime
+          coerce: datetime
+          max: 2024-01-01 00:00:00
+          meta:
+          - ruleID: greater_than_max_value
+            meta:
+            - partID: lastEdited
+              maxValue: "2024-01-01"
+              sites: header
+      meta:
+        - partID: sites
+          partType: table

--- a/assets/validation-rules/greater-than-max-value/valid-dataset-4.yml
+++ b/assets/validation-rules/greater-than-max-value/valid-dataset-4.yml
@@ -1,0 +1,4 @@
+- siteID: 1
+  lastEdited: "2023-01-30"
+- siteID: 2
+  lastEdited: "2023-01-30T00:00:00"

--- a/assets/validation-rules/less-than-min-value/error-report-pass-2.json
+++ b/assets/validation-rules/less-than-min-value/error-report-pass-2.json
@@ -1,0 +1,47 @@
+{
+    "errors": [],
+    "warnings": [
+        {
+            "warningType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
+            "tableName": "sites",
+            "columnName": "geoLat",
+            "rowNumber": 1,
+            "row": {
+                "siteID": "1",
+                "geoLat": "-89",
+                "geoLong": "-90"
+            },
+            "invalidValue": "-89",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLat",
+                    "minValue": "-90",
+                    "sites": "header"
+                }
+            ],
+            "message": "Value -89 in row 1 in column geoLat in table sites is a string and was coerced into a number"
+        },
+        {
+            "warningType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
+            "tableName": "sites",
+            "columnName": "geoLong",
+            "rowNumber": 1,
+            "row": {
+                "siteID": "1",
+                "geoLat": "-89",
+                "geoLong": "-90"
+            },
+            "invalidValue": "-90",
+            "validationRuleFields": [
+                {
+                    "partID": "geoLong",
+                    "minValue": "-90.15",
+                    "sites": "header"
+                }
+            ],
+            "message": "Value -90 in row 1 in column geoLong in table sites is a string and was coerced into a number"
+        }
+    ]
+}

--- a/assets/validation-rules/less-than-min-value/error-report-pass-4.json
+++ b/assets/validation-rules/less-than-min-value/error-report-pass-4.json
@@ -1,25 +1,5 @@
 {
-    "errors": [
-        {
-            "errorType": "less_than_min_value",
-            "tableName": "sites",
-            "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
-                "siteID": 1,
-                "lastEdited": "2022-12-30 00:00:00"
-            },
-            "invalidValue": "2022-12-30 00:00:00",
-            "validationRuleFields": [
-                {
-                    "partID": "lastEdited",
-                    "minValue": "2023-01-01",
-                    "sites": "header"
-                }
-            ],
-            "message": "Value 2022-12-30 00:00:00 in row 1 in column lastEdited in table sites is less than the allowable minimum value of 2023-01-01 00:00:00"
-        }
-    ],
+    "errors": [],
     "warnings": [
         {
             "warningType": "_coercion",
@@ -28,10 +8,10 @@
             "columnName": "lastEdited",
             "rowNumber": 1,
             "row": {
-                "lastEdited": "2022-12-30",
-                "siteID": 1
+                "siteID": 1,
+                "lastEdited": "2023-01-30"
             },
-            "invalidValue": "2022-12-30",
+            "invalidValue": "2023-01-30",
             "validationRuleFields": [
                 {
                     "partID": "lastEdited",
@@ -39,7 +19,27 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2022-12-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "Value 2023-01-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+        },
+        {
+            "warningType": "_coercion",
+            "coercionRules": ["less_than_min_value"],
+            "tableName": "sites",
+            "columnName": "lastEdited",
+            "rowNumber": 2,
+            "row": {
+                "siteID": 2,
+                "lastEdited": "2023-01-30T00:00:00"
+            },
+            "invalidValue": "2023-01-30T00:00:00",
+            "validationRuleFields": [
+                {
+                    "partID": "lastEdited",
+                    "minValue": "2023-01-01",
+                    "sites": "header"
+                }
+            ],
+            "message": "Value 2023-01-30T00:00:00 in row 2 in column lastEdited in table sites is a string and was coerced into a datetime"
         }
     ]
 }

--- a/assets/validation-rules/less-than-min-value/invalid-dataset-4.yml
+++ b/assets/validation-rules/less-than-min-value/invalid-dataset-4.yml
@@ -1,0 +1,2 @@
+- siteID: 1
+  lastEdited: "2022-12-30"

--- a/assets/validation-rules/less-than-min-value/parts-datetime.csv
+++ b/assets/validation-rules/less-than-min-value/parts-datetime.csv
@@ -1,0 +1,2 @@
+partID,partType,sites,dataType,minValue,version1Location,version1Table,version1Variable,status
+lastEdited,attribute,header,datetime,2023-01-01,variables,NA,LastEdited,active

--- a/assets/validation-rules/less-than-min-value/schema-datetime-v1.yml
+++ b/assets/validation-rules/less-than-min-value/schema-datetime-v1.yml
@@ -1,0 +1,24 @@
+schemaVersion: 1.0.0
+schema:
+  Site:
+    type: list
+    schema:
+      type: dict
+      schema:
+        LastEdited:
+          type: datetime
+          coerce: datetime
+          min: 2023-01-01 00:00:00
+          meta:
+          - ruleID: less_than_min_value
+            meta:
+            - partID: lastEdited
+              minValue: "2023-01-01"
+              sites: header
+              version1Location: variables
+              version1Variable: LastEdited
+      meta:
+        - partID: sites
+          partType: table
+          version1Location: tables
+          version1Table: Site

--- a/assets/validation-rules/less-than-min-value/schema-datetime-v2.yml
+++ b/assets/validation-rules/less-than-min-value/schema-datetime-v2.yml
@@ -1,0 +1,20 @@
+schemaVersion: 2.0.0
+schema:
+  sites:
+    type: list
+    schema:
+      type: dict
+      schema:
+        lastEdited:
+          type: datetime
+          coerce: datetime
+          min: 2023-01-01 00:00:00
+          meta:
+          - ruleID: less_than_min_value
+            meta:
+            - partID: lastEdited
+              minValue: "2023-01-01"
+              sites: header
+      meta:
+        - partID: sites
+          partType: table

--- a/assets/validation-rules/less-than-min-value/valid-dataset-4.yml
+++ b/assets/validation-rules/less-than-min-value/valid-dataset-4.yml
@@ -1,0 +1,4 @@
+- siteID: 1
+  lastEdited: "2023-01-30"
+- siteID: 2
+  lastEdited: "2023-01-30T00:00:00"

--- a/docs/validation-rules/less_than_min_value.qmd
+++ b/docs/validation-rules/less_than_min_value.qmd
@@ -114,7 +114,7 @@ Finally, for the valid coercable dataset (valid dataset 2) above, the following 
 
 ```{python}
 #| echo: false
-pprint_json_file(asset("error-report-4.json"))
+pprint_json_file(asset("error-report-pass-2.json"))
 ```
 
 ## Rule metadata

--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -24,13 +24,18 @@ from stdext import (
 EMPTY_TRIMMED_RULE = 0x101
 
 
-def _convert_value(orig_value, type_class) -> int:
-    if type_class is int:
-        return parse_int(orig_value)
-    elif type_class is datetime:
-        return parse_datetime(orig_value)
+def _convert_value(val: Any, type_class) -> Any:
+    "Convert `val` to `type_class`."
+    # `parse_int` is explicitly called because floats without decimals
+    # (ex: 1.0) also are valid integers.
+    if isinstance(val, type_class):
+        return val
+    elif type_class is int:
+        return parse_int(val)
+    elif type_class is datetime and isinstance(val, str):
+        return parse_datetime(val)
     else:
-        return type_class(orig_value)
+        return type_class(val)
 
 
 class ContextualCoercer(Validator):

--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -2,7 +2,6 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 from copy import deepcopy
 # from pprint import pprint
@@ -11,7 +10,8 @@ from cerberus import Validator
 from cerberus.errors import ErrorDefinition
 
 import part_tables as pt
-import rules as validation_rules
+import reports
+from rules import COERCION_RULE_ID
 from part_tables import Row
 from stdext import (
     inc,
@@ -21,69 +21,7 @@ from stdext import (
 )
 
 
-class LogLevel(Enum):
-    WARNING = 'warning'
-    ERROR = 'error'
-
-
-@dataclass(frozen=True)
-class CoercionCtx:
-    """Coercion context."""
-    cerb_type_name: str
-    column: str
-    column_meta: dict
-    row: dict
-    row_num: str
-    table: str
-    value: str
-
-
 EMPTY_TRIMMED_RULE = 0x101
-
-
-def _get_meta_rule_ids(column_meta) -> List[str]:
-    if not column_meta:
-        return []
-    return [m['ruleID'] for m in column_meta]
-
-
-def _generalize_cerb_type_name(name: str) -> str:
-    if name in {'float', 'integer'}:
-        return 'number'
-    else:
-        return name
-
-
-def _gen_coercion_msg(lvl: LogLevel, ctx: CoercionCtx):
-    orig_type_name = type_name(type(ctx.value))
-    coerced_type_alias = _generalize_cerb_type_name(ctx.cerb_type_name)
-    result = (f'Value {ctx.value} in row {ctx.row_num} in column {ctx.column} '
-              f'in table {ctx.table} ')
-    if lvl == LogLevel.WARNING:
-        result += f'is a {orig_type_name} and was '
-    elif lvl == LogLevel.ERROR:
-        result += 'cannot be '
-    else:
-        assert False, "invalid log lvl"
-    result += f'coerced into a {coerced_type_alias}'
-    return result
-
-
-def _gen_coercion_log_entry(log_lvl, ctx):
-    rule_ids = _get_meta_rule_ids(ctx.column_meta)
-    rule_fields = pt.get_validation_rule_fields(ctx.column_meta, rule_ids)
-    msg = _gen_coercion_msg(log_lvl, ctx)
-    return {
-        (log_lvl.value + 'Type'): validation_rules._COERCION,
-        'coercionRules': rule_ids,
-        'tableName': ctx.table,
-        'columnName': ctx.column,
-        'rowNumber': ctx.row_num,
-        'row': ctx.row,
-        'invalidValue': ctx.value,
-        'validationRuleFields': rule_fields,
-        'message': msg
-    }
 
 
 def _convert_value(orig_value, type_class) -> int:
@@ -155,9 +93,9 @@ class ContextualCoercer(Validator):
             logging.error(self.errors, stack_info=True)
         return self._config["coerced_document"]
 
-    def _log_coercion(self, lvl, ctx):
-        entry = _gen_coercion_log_entry(lvl, ctx)
-        self._config[lvl.value + 's'].append(entry)
+    def _log_coercion(self, kind, ctx):
+        entry = reports.gen_coercion_error(ctx, kind)
+        self._config[kind.value + 's'].append(entry)
 
     def _set_value(self, field, orig_value, type_class):
         if isinstance(orig_value, type_class):
@@ -168,22 +106,23 @@ class ContextualCoercer(Validator):
         row_ix = self.document_path[1]
         row = self.document
         column_meta = self.schema[field].get('meta')
-        ctx = CoercionCtx(
+        ctx = reports.ErrorCtx(
+            rule_id=COERCION_RULE_ID,
             cerb_type_name=type_name(type_class),
-            column=field,
+            column_id=field,
             column_meta=column_meta,
-            row=row,
-            row_num=row_ix+1,
-            table=table,
+            rows=[row],
+            row_numbers=[inc(row_ix)],
+            table_id=table,
             value=orig_value,
         )
         try:
             value = _convert_value(orig_value, type_class)
             self._config["coerced_document"][table][row_ix][field] = value
-            self._log_coercion(LogLevel.WARNING, ctx)
+            self._log_coercion(reports.ErrorKind.WARNING, ctx)
         except (ArithmeticError, ValueError):
             value = orig_value
-            self._log_coercion(LogLevel.ERROR, ctx)
+            self._log_coercion(reports.ErrorKind.ERROR, ctx)
 
     def _check_with_datetime(self, field, value):
         self._set_value(field, value, datetime)

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -1,0 +1,165 @@
+import datetime
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, List, Optional, Set
+# from pprint import pprint
+
+import part_tables as pt
+from rules import COERCION_RULE_ID
+from stdext import (
+    get_len,
+    type_name,
+)
+
+
+class ErrorKind(Enum):
+    WARNING = 'warning'
+    ERROR = 'error'
+
+
+@dataclass(frozen=True)
+class ErrorCtx:
+    column_id: str
+    column_meta: dict
+    row_numbers: List[int]
+    rows: List[dict]
+    rule_id: str
+    table_id: str
+    value: Any
+
+    allowed_values: Set[str] = field(default_factory=set)
+    cerb_type_name: str = ''
+    constraint: Any = None
+    err_template: str = ''
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    data_version: str
+    schema_version: str
+    package_version: str
+    errors: List[str]
+    warnings: List[str]
+
+    def valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+def _fmt_list(items: list) -> str:
+    if len(items) > 1:
+        return ','.join(map(str, items))
+    else:
+        return str(items[0])
+
+
+def _fmt_value(val: Any) -> Any:
+    # needed to avoid the default `datetime.datetime(year, month, day, ...)`
+    if isinstance(val, datetime.date) or isinstance(val, datetime.datetime):
+        return str(val)
+    return val
+
+
+def _fmt_dataset_values(rows: List[pt.Row]) -> List[pt.Row]:
+    """Returns a copy of `rows` with formated values."""
+    def _fmt_row(row: pt.Row) -> pt.Row:
+        return {key: _fmt_value(val) for key, val in row.items()}
+
+    return list(map(_fmt_row, rows))
+
+
+def _fmt_rule_name(rule_id: str):
+    return rule_id.replace('_', ' ').capitalize()
+
+
+def _fmt_allowed_values(values: Set[str]) -> str:
+    # XXX: The order of set-elements isn't deterministic, so we need to sort.
+    return '/'.join(sorted(values))
+
+
+def _gen_error_msg(ctx: ErrorCtx, template: Optional[str] = None):
+    ":param template: overrides ctx.err_template"
+    if not template:
+        template = ctx.err_template
+    return template.format(
+        allowed_values=_fmt_allowed_values(ctx.allowed_values),
+        column_id=ctx.column_id,
+        constraint=_fmt_value(ctx.constraint),
+        row_num=_fmt_list(ctx.row_numbers),
+        rule_name=_fmt_rule_name(ctx.rule_id),
+        table_id=ctx.table_id,
+        value=_fmt_value(ctx.value),
+        value_len=get_len(ctx.value),
+        value_type=type_name(type(ctx.value)),
+    )
+
+
+def gen_rule_error(ctx: ErrorCtx,
+                   err_template: Optional[str] = None,
+                   kind: Optional[ErrorKind] = None,
+                   ) -> dict:
+    """
+    :param err_template: overrides rule error-template
+    """
+    rule_ids = _get_meta_rule_ids(ctx.column_meta)
+    rule_fields = pt.get_validation_rule_fields(ctx.column_meta, rule_ids)
+    error = {
+        (kind.value + 'Type'): ctx.rule_id,
+        'tableName': ctx.table_id,
+        'columnName': ctx.column_id,
+        'validationRuleFields': _fmt_dataset_values(rule_fields),
+        'message': _gen_error_msg(ctx, err_template),
+    }
+
+    # row numbers
+    if len(ctx.row_numbers) > 1:
+        error['rowNumbers'] = ctx.row_numbers
+    else:
+        error['rowNumber'] = ctx.row_numbers[0]
+
+    # rows
+    rows = _fmt_dataset_values(ctx.rows)
+    if len(ctx.rows) > 1:
+        error['rows'] = rows
+    else:
+        error['row'] = rows[0]
+
+    # value
+    if ctx.value is not None:
+        error['invalidValue'] = _fmt_value(ctx.value)
+
+    # coercion
+    if ctx.rule_id == COERCION_RULE_ID:
+        error['coercionRules'] = rule_ids
+
+    return error
+
+
+def _generalize_cerb_type_name(name: str) -> str:
+    if name in {'float', 'integer'}:
+        return 'number'
+    else:
+        return name
+
+
+def _get_meta_rule_ids(column_meta) -> Set[str]:
+    if not column_meta:
+        return []
+    return [m['ruleID'] for m in column_meta]
+
+
+def _gen_coercion_msg(ctx: ErrorCtx, kind: ErrorKind):
+    orig_type_name = type_name(type(ctx.value))
+    coerced_type_alias = _generalize_cerb_type_name(ctx.cerb_type_name)
+    result = ('Value {value} in row {row_num} in column {column_id} '
+              'in table {table_id} ')
+    if kind == ErrorKind.WARNING:
+        result += f'is a {orig_type_name} and was '
+    else:
+        result += 'cannot be '
+    result += f'coerced into a {coerced_type_alias}'
+    return result
+
+
+def gen_coercion_error(ctx, kind: ErrorKind):
+    msg = _gen_coercion_msg(ctx, kind)
+    return gen_rule_error(ctx, err_template=msg, kind=kind)

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -1,13 +1,18 @@
 import logging
 from dataclasses import dataclass
 from logging import warning
-from typing import Callable, List, Optional, Set
+from typing import Any, Callable, List, Optional, Set
 # from pprint import pprint
 
 import part_tables as pt
 from part_tables import Meta, MetaEntry, Part, PartData, PartId
 from schemas import init_attr_schema, init_table_schema
-from stdext import deep_update
+from stdext import (
+    deep_update,
+    parse_datetime,
+    try_parse_float,
+    try_parse_int,
+)
 from versions import Version
 
 AttrPredicate = Callable[[pt.TableId, Part], bool]
@@ -245,3 +250,19 @@ def gen_cerb_rules_for_type(val_ctx: OdmValueCtx):
     if odm_type == 'boolean':
         result['allowed'] = sorted(val_ctx.bool_set)
     return result
+
+
+def parse_odm_val(val_ctx: OdmValueCtx) -> Optional[Any]:
+    """Parses the ODM value from `val_ctx`."""
+    val = val_ctx.value
+    kind = val_ctx.datatype
+    if not val:
+        return
+    if kind == 'integer':
+        return try_parse_int(val)
+    elif kind == 'float':
+        return try_parse_float(val)
+    elif kind == 'datetime':
+        return parse_datetime(val)
+    else:
+        assert False, f'{kind} parsing not impl.'

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -65,20 +65,12 @@ def get_part_ids(parts: List[Part]) -> List[PartId]:
     return list(map(pt.get_partID, parts))
 
 
-def get_mapped_table_id(data: PartData, table_id: PartId,
+def _get_mapped_part_id(data: PartData, part_id: PartId,
                         version: Version) -> PartId:
     if version.major == 1:
-        return data.mappings[table_id][0]
+        return data.mappings[part_id][0]
     else:
-        return table_id
-
-
-def get_mapped_attr_id(data: PartData, attr_id: PartId,
-                       version: Version) -> PartId:
-    if version.major == 1:
-        return data.mappings[attr_id][0]
-    else:
-        return attr_id
+        return part_id
 
 
 def table_items(data: PartData, version: Version):
@@ -87,7 +79,7 @@ def table_items(data: PartData, version: Version):
     Yields a tuple of: (original id, mapped id, part).
     """
     for table_id0, td in data.table_data.items():
-        table_id1 = get_mapped_table_id(data, table_id0, version)
+        table_id1 = _get_mapped_part_id(data, table_id0, version)
         table = td.part
         yield (table_id0, table_id1, table)
 
@@ -103,7 +95,7 @@ def catset_items(data: PartData, version: Version):
 
     Yields a tuple of: (original id, mapped id, part)."""
     for attr_id0, cs_data in data.catset_data.items():
-        attr_id1 = get_mapped_attr_id(data, attr_id0, version)
+        attr_id1 = _get_mapped_part_id(data, attr_id0, version)
         yield (attr_id0, attr_id1, cs_data)
 
 
@@ -113,7 +105,7 @@ def attr_items(data: PartData, table_id: PartId, version: Version):
     Yields a tuple of: (original id, mapped id, part)."""
     for attr in data.table_data[table_id].attributes:
         attr_id0 = pt.get_partID(attr)
-        attr_id1 = get_mapped_attr_id(data, attr_id0, version)
+        attr_id1 = _get_mapped_part_id(data, attr_id0, version)
         yield (attr_id0, attr_id1, attr)
 
 
@@ -138,7 +130,7 @@ def init_table_schema2(schema, data, table, version):
     # This is not part of module 'schemas' due to simplicity. It has
     # dependencies in this file and the modules may be merged soon enough.
     table_id0 = pt.get_partID(table)
-    table_id1 = get_mapped_table_id(data, table_id0, version)
+    table_id1 = _get_mapped_part_id(data, table_id0, version)
     table_meta = get_table_meta(table, version)
     return init_table_schema(table_id1, table_meta, {})
 
@@ -148,7 +140,7 @@ def set_attr_schema(table_schema, data, table, attr, rule_id,
     table_id0 = pt.get_partID(table)
     table_id1 = list(table_schema.keys())[0]
     attr_id0 = pt.get_partID(attr)
-    attr_id1 = get_mapped_attr_id(data, attr_id0, version)
+    attr_id1 = _get_mapped_part_id(data, attr_id0, version)
     attr_meta = _get_attr_meta(attr, table_id0, version, odm_key)
     attr_schema = init_attr_schema(attr_id1, rule_id, cerb_rules, attr_meta)
     deep_update(table_schema[table_id1]['schema']['schema'], attr_schema)

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, List, Tuple
 import part_tables as pt
 from schemas import Schema, update_schema
 from stdext import (
-    try_parse_float,
     try_parse_int,
 )
 from rule_primitives import (
@@ -22,6 +21,7 @@ from rule_primitives import (
     get_catset_meta,
     get_table_meta,
     is_mandatory,
+    parse_odm_val,
     table_items,
 )
 from versions import Version
@@ -120,7 +120,7 @@ def greater_than_max_value():
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {
-            'max': try_parse_float(val_ctx.value)
+            'max': parse_odm_val(val_ctx)
         } | gen_cerb_rules_for_type(val_ctx)
 
     def gen_schema(data: pt.PartData, ver):
@@ -188,7 +188,7 @@ def less_than_min_value():
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {
-            'min': try_parse_float(val_ctx.value)
+            'min': parse_odm_val(val_ctx)
         } | gen_cerb_rules_for_type(val_ctx)
 
     def gen_schema(data: pt.PartData, ver):

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -26,7 +26,7 @@ from rule_primitives import (
 )
 from versions import Version
 
-_COERCION = '_coercion'
+COERCION_RULE_ID = '_coercion'
 
 
 @dataclass(frozen=True)

--- a/src/odm_validation/stdext.py
+++ b/src/odm_validation/stdext.py
@@ -11,13 +11,19 @@ def get_len(x: Any) -> int:
     return len(x) if getattr(x, '__len__', None) else 0
 
 
+def hash2(x) -> int:
+    """An alternative hash function that can hash anything."""
+    if isinstance(x, dict):
+        return hash(json.dumps(x, sort_keys=True))
+    else:
+        return hash(x)
+
+
 def deep_update(dst: dict, src: dict):
     """
     Recursively update a dict.
     Subdict's won't be overwritten but also updated.
     List values will be joined, but not recursed.
-
-    Warning: List items may be duplicated.
 
     Originally from: https://stackoverflow.com/a/8310229
     """
@@ -28,25 +34,13 @@ def deep_update(dst: dict, src: dict):
             deep_update(dst[key], value)
         elif isinstance(value, list):
             src_list = value
-            if len(src_list) > 0:
-                dst_list = dst[key]
-                dst_list += src_list
-
-
-def hash_dict(d) -> str:
-    json.dumps(d, sort_keys=True)
-
-
-def deduplicate_list(items: List[Any]) -> List[Any]:
-    return list(set(items))
-
-
-def deduplicate_dict_list(dicts: List[dict]) -> List[dict]:
-    assert isinstance(dicts, list)
-    assert len(dicts) == 0 or isinstance(dicts[0], dict)
-    hashes = map(hash_dict, dicts)
-    unique_dict = dict(zip(hashes, dicts))
-    return list(unique_dict.values())
+            if len(src_list) == 0:
+                continue
+            dst_list = dst[key]
+            dst_hashset = set(map(hash2, dst_list))
+            for item in src_list:
+                if hash2(item) not in dst_hashset:
+                    dst_list.append(item)
 
 
 def strip_dict_key(d: dict, target_key: str):

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -7,7 +7,6 @@ import os
 import re
 import sys
 from copy import deepcopy
-from dataclasses import dataclass
 from itertools import groupby
 from os.path import join, normpath
 from pathlib import Path
@@ -17,44 +16,17 @@ from typing import Any, Dict, List, Optional, Set
 from cerberusext import ContextualCoercer, OdmValidator
 
 import part_tables as pt
+import reports
 import rules
+from reports import ErrorKind
 from rules import Rule, ruleset
 from schemas import CerberusSchema, Schema, init_table_schema
 from stdext import (
     deep_update,
     flatten,
-    get_len,
     strip_dict_key,
-    type_name,
 )
 from versions import __version__, parse_version
-
-
-@dataclass(frozen=True)
-class ErrorContext:
-    allowed_values: Set[str]
-    column_id: str
-    constraint: Any
-    odm_datatype: str
-    rows: List[dict]
-    row_numbers: List[int]
-    rule: Rule
-    rule_fields: list
-    table_id: str
-    value: Any
-    is_warning: bool
-
-
-@dataclass(frozen=True)
-class ValidationReport:
-    data_version: str
-    schema_version: str
-    package_version: str
-    errors: List[str]
-    warnings: List[str]
-
-    def valid(self) -> bool:
-        return len(self.errors) == 0
 
 
 def _get_latest_odm_version() -> str:
@@ -94,70 +66,6 @@ ODM_LATEST = _get_latest_odm_version()
 
 # private constants
 _KEY_RULES = _gen_cerb_rule_map()
-
-
-def _prettify_rule_name(rule: Rule):
-    return rule.id.replace('_', ' ').capitalize()
-
-
-def _fmt_allowed_values(values: Set[str]) -> str:
-    # XXX: The order of set-elements isn't deterministic, so we need to sort.
-    return '/'.join(sorted(values))
-
-
-def _fmt_list(items: list) -> str:
-    if len(items) > 1:
-        return ','.join(map(str, items))
-    else:
-        return str(items[0])
-
-
-def _error_msg(ctx: ErrorContext):
-    error_template = ctx.rule.get_error_template(ctx.value, ctx.odm_datatype)
-    return error_template.format(
-        allowed_values=_fmt_allowed_values(ctx.allowed_values),
-        rule_name=_prettify_rule_name(ctx.rule),
-        table_id=ctx.table_id,
-        column_id=ctx.column_id,
-        row_num=_fmt_list(ctx.row_numbers),
-        value=ctx.value,
-        value_len=get_len(ctx.value),
-        value_type=type_name(type(ctx.value)),
-        constraint=ctx.constraint,
-    )
-
-
-def _gen_rule_error(ctx: ErrorContext):
-    error = {
-        'tableName': ctx.table_id,
-        'columnName': ctx.column_id,
-        'validationRuleFields': ctx.rule_fields,
-        'message': _error_msg(ctx),
-    }
-
-    # type
-    if ctx.is_warning:
-        error['warningType'] = ctx.rule.id
-    else:
-        error['errorType'] = ctx.rule.id
-
-    # row numbers
-    if len(ctx.row_numbers) > 1:
-        error['rowNumbers'] = ctx.row_numbers
-    else:
-        error['rowNumber'] = ctx.row_numbers[0]
-
-    # rows
-    if len(ctx.rows) > 1:
-        error['rows'] = ctx.rows
-    else:
-        error['row'] = ctx.rows[0]
-
-    # value
-    if ctx.value is not None:
-        error['invalidValue'] = ctx.value
-
-    return error
 
 
 def _get_ruleId(x):
@@ -215,15 +123,21 @@ def _gen_error_entry(cerb_rule, table_id, column_id, value, row_numbers,
     # XXX: depends on meta (which should only be for debug)
     odm_datatype = _extract_datatype(column_meta)
 
-    rule_fields = pt.get_validation_rule_fields(column_meta, [rule.id])
+    # rule_fields = pt.get_validation_rule_fields(column_meta, [rule.id])
     allowed = _get_allowed_values(schema_column) if schema_column else []
-    error_ctx = ErrorContext(rule=rule, table_id=table_id, column_id=column_id,
-                             row_numbers=row_numbers, rows=rows, value=value,
-                             constraint=constraint, rule_fields=rule_fields,
-                             allowed_values=allowed,
-                             odm_datatype=odm_datatype,
-                             is_warning=rule.is_warning)
-    return _gen_rule_error(error_ctx)
+    kind = ErrorKind.WARNING if rule.is_warning else ErrorKind.ERROR
+    error_ctx = reports.ErrorCtx(
+        allowed_values=allowed,
+        column_id=column_id,
+        column_meta=column_meta,
+        constraint=constraint,
+        err_template=rule.get_error_template(value, odm_datatype),
+        row_numbers=row_numbers,
+        rows=rows, value=value,
+        rule_id=rule.id,
+        table_id=table_id,
+    )
+    return reports.gen_rule_error(error_ctx, kind=kind)
 
 
 def _gen_cerb_error_entry(e, row, schema: CerberusSchema,
@@ -293,7 +207,7 @@ def _filter_errors(errors):
     """Removes redundant errors."""
     # - invalid_type produces redundant _coercion errors
     result = []
-    target_rule_ids = {rules._COERCION}
+    target_rule_ids = {rules.COERCION_RULE_ID}
     sorted_errors = _sort_errors(errors)
     for tableName, table_errors in groupby(sorted_errors, _get_table_name):
         for rowNum, row_errors in groupby(table_errors, _get_row_num):
@@ -406,7 +320,7 @@ def _validate_data_ext(schema: Schema,
                        data: dict,
                        data_version: str = ODM_LATEST,
                        rule_whitelist: List[str] = [],
-                       ) -> ValidationReport:
+                       ) -> reports.ValidationReport:
     """Validates `data` with `schema`, using Cerberus."""
     # `rule_whitelist` determines which rules/errors are triggered during
     # validation. It is needed when testing data validation, to be able to
@@ -435,7 +349,7 @@ def _validate_data_ext(schema: Schema,
 
     errors = _filter_errors(errors)
 
-    return ValidationReport(
+    return reports.ValidationReport(
         data_version=data_version,
         schema_version=versioned_schema["schemaVersion"],
         package_version=__version__,
@@ -447,5 +361,5 @@ def _validate_data_ext(schema: Schema,
 def validate_data(schema: Schema,
                   data: dict,
                   data_version=ODM_LATEST,
-                  ) -> ValidationReport:
+                  ) -> reports.ValidationReport:
     return _validate_data_ext(schema, data, data_version)

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -21,7 +21,6 @@ import rules
 from rules import Rule, ruleset
 from schemas import CerberusSchema, Schema, init_table_schema
 from stdext import (
-    deduplicate_dict_list,
     deep_update,
     flatten,
     get_len,
@@ -386,15 +385,10 @@ def _generate_validation_schema_ext(parts, schema_version,
     additions_schema = _gen_additions_schema(schema_additions)
     deep_update(cerb_schema, additions_schema)
 
-    # `deep_update` is used to join all the table-schemas together,
-    # however it will cause duplicates in the meta list. This is especially a
-    # problem for the table-meta, so we'll need to deduplicate it here.
+    # strip empty tables
     for table in list(cerb_schema):
-        table_schema = cerb_schema[table]['schema']
-        if table_schema['schema'] == {}:
+        if cerb_schema[table]['schema']['schema'] == {}:
             del cerb_schema[table]
-            continue
-        table_schema['meta'] = deduplicate_dict_list(table_schema['meta'])
 
     return {
         "schemaVersion": schema_version,

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -114,14 +114,14 @@ class TestCoercion(common.OdmTestCase):
 
     def test_extract_coercion_schema(self):
         result = ContextualCoercer._extract_coercion_schema(cerb_schema)
-        self.assertEqual(result, coercion_schema)
+        self.assertEqual(coercion_schema, result)
 
     def test_coerce(self):
         warnings = []
         v = ContextualCoercer(warnings=warnings)
         result = v.coerce(data, cerb_schema)
-        self.assertEqual(result, coerced_data)
-        self.assertEqual(warnings, expected_coercion_warnings)
+        self.assertEqual(coerced_data, result)
+        self.assertEqual(expected_coercion_warnings, warnings)
 
     def test_validation(self):
         report = _validate_data_ext(schema, data)

--- a/tests/test_min_max_value.py
+++ b/tests/test_min_max_value.py
@@ -6,11 +6,11 @@ from parameterized import parameterized, parameterized_class
 
 import common
 from common import asset, root_dir, param_range
+from stdext import deep_update
 from utils import (
     import_dataset,
     import_json_file,
     import_schema,
-    import_yaml_file
 )
 from validation import _generate_validation_schema_ext, _validate_data_ext
 
@@ -21,36 +21,38 @@ class Assets():
         common.ASSET_DIR = join(root_dir,
                                 f'assets/validation-rules/{rule_dirname}')
 
-        self.parts_v2 = import_dataset(asset('parts.csv'))
+        datetime_parts = import_dataset(asset('parts-datetime.csv'))
+        datetime_schema_v1 = import_schema(asset('schema-datetime-v1.yml'))
+        datetime_schema_v2 = import_schema(asset('schema-datetime-v2.yml'))
+
+        self.parts = (import_dataset(asset('parts.csv')) + datetime_parts)
         self.schemas = {
             1: import_schema(asset('schema-v1.yml')),
             2: import_schema(asset('schema-v2.yml')),
         }
+        deep_update(self.schemas[1], datetime_schema_v1)
+        deep_update(self.schemas[2], datetime_schema_v2)
 
-        self.data_pass_v2 = [
-            {'sites': import_dataset(asset('valid-dataset-1.yml'))},
-            {'sites': import_dataset(asset('valid-dataset-2.csv'))},
-            {'sites': import_dataset(asset('valid-dataset-3.yml'))},
-        ]
-
-        self.data_fail_v2 = [
-            {'sites': import_yaml_file(asset('invalid-dataset-1.yml'))},
-            {'sites': import_dataset(asset('invalid-dataset-2.csv'))},
-            {'sites': import_dataset(asset('invalid-dataset-3.csv'))},
-        ]
-
-        self.error_report_fail = [
-            import_json_file(asset('error-report-1.json')),
-            import_json_file(asset('error-report-2.json')),
-            import_json_file(asset('error-report-3.json')),
-        ]
-
+        self.data_pass = []
+        for i in range(1, 5):
+            self.data_pass.append({
+                'sites': import_dataset(asset(f'valid-dataset-{i}.*'))
+            })
         empty_report = {'errors': [], 'warnings': []}
         self.error_report_pass = [
             empty_report,
-            import_json_file(asset('error-report-4.json')),
+            import_json_file(asset('error-report-pass-2.json')),
             empty_report,
+            import_json_file(asset('error-report-pass-4.json')),
         ]
+
+        self.data_fail = []
+        self.error_report_fail = []
+        for i in range(1, 5):
+            self.data_fail.append(
+                {'sites': import_dataset(asset(f'invalid-dataset-{i}.*'))})
+            self.error_report_fail.append(
+                import_json_file(asset(f'error-report-{i}.json')))
 
 
 @parameterized_class([
@@ -69,23 +71,23 @@ class TestMinMaxValue(common.OdmTestCase):
     @parameterized.expand(param_range(1, 3))
     def test_schema_generation(self, major_ver):
         result = _generate_validation_schema_ext(
-            parts=self.assets.parts_v2,
+            parts=self.assets.parts,
             schema_version=f'{major_ver}.0.0',
             rule_whitelist=[self.ruleId])
         self.assertDictEqual(self.assets.schemas[major_ver], result)
 
-    @parameterized.expand(param_range(0, 3))
+    @parameterized.expand(param_range(0, 4))
     def test_passing_datasets(self, ix):
         report = _validate_data_ext(self.assets.schemas[2],
-                                    self.assets.data_pass_v2[ix],
+                                    self.assets.data_pass[ix],
                                     rule_whitelist=self.whitelist)
         expected = self.assets.error_report_pass[ix]
         self.assertReportEqual(expected, report)
 
-    @parameterized.expand(param_range(0, 3))
+    @parameterized.expand(param_range(0, 4))
     def test_failing_datasets(self, ix):
         report = _validate_data_ext(self.assets.schemas[2],
-                                    self.assets.data_fail_v2[ix],
+                                    self.assets.data_fail[ix],
                                     rule_whitelist=self.whitelist)
         expected = self.assets.error_report_fail[ix]
         self.assertReportEqual(expected, report)

--- a/tests/test_stdext.py
+++ b/tests/test_stdext.py
@@ -1,7 +1,7 @@
 import unittest
 
 import common
-from stdext import deduplicate_dict_list, try_parse_int
+from stdext import try_parse_int
 
 common.unused_import_dummy = 1
 
@@ -9,10 +9,6 @@ common.unused_import_dummy = 1
 class TestStdExt(common.OdmTestCase):
     def setUp(self):
         self.maxDiff = None
-
-    def test_deduplicate_dict_list(self):
-        d = {'a': 1}
-        self.assertEqual(deduplicate_dict_list([d, d]), [d])
 
     def test_try_parse_int(self):
         self.assertEqual(try_parse_int('1'), 1)


### PR DESCRIPTION
fixes #97

- refactor error reporting to unify coercion and normal error logic in new module 'reports'
- fix datetime parsing/conversion
- extend min/max-rule tests with datetime