### PR TITLE
fix version1table mapping

### DIFF
--- a/assets/validation-rules/duplicate-entries-found/parts.csv
+++ b/assets/validation-rules/duplicate-entries-found/parts.csv
@@ -1,3 +1,4 @@
 partID,partType,addresses,version1Location,version1Table,version1Variable,status
 addresses,table,NA,tables,Address,NA,active
 addId,attribute,pK,variables,Address,AddressId,active
+addL1,attribute,header,variables,Address,AddL1,active

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -192,6 +192,7 @@ def is_compatible(part, version: Version) -> bool:
 
 
 def _parse_version1Field(part, key) -> List[str]:
+    "`key` must be one of the part columns that starts with 'version1*'."
     val = part.get(key)
     if not val:
         return []

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -170,11 +170,12 @@ def get_version_range(part: dict) -> (Version, Version):
     return (first, last)
 
 
-def is_compatible(active: bool, first: Version, last: Version,
-                  schema_version: Version) -> bool:
-    """Returns True if part is compatible with `schema_version`."""
+def is_compatible(part, version: Version) -> bool:
+    """Returns True if part is compatible with `version`."""
     # not (v < first) and ((v < last) or active)
-    v = schema_version
+    v = version
+    first, last = get_version_range(part)
+    active = (part.get(STATUS) == ACTIVE)
     if v.compare(first) < 0:
         return False
     if v.compare(last) < 0:
@@ -334,11 +335,10 @@ def filter_compatible(parts: Dataset, schema_version: Version) -> Dataset:
     result = []
     for row in parts:
         part_id = get_partID(row)
-        first, last = get_version_range(row)
-        active: bool = row.get(STATUS) == ACTIVE
-        if not (is_compatible(active, first, last, schema_version)):
+        if not (is_compatible(row, schema_version)):
             warning(f'skipping incompatible part: {part_id}')
             continue
+        _, last = get_version_range(row)
         if last.major > schema_version.major:
             if not has_mapping(row, schema_version):
                 error(f'skipping part with missing version1 fields: {part_id}')

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -172,8 +172,11 @@ def get_version_range(part: dict) -> (Version, Version):
 
 def is_compatible(part, version: Version) -> bool:
     """Returns True if part is compatible with `version`."""
-    # not (v < first) and ((v < last) or active)
+    # XXX: prerelease (like rc.3, etc.) must be stripped from `version`
+    # before compare, because `v2.0.0-rc.3` < `v.2.0.0`.
+    # logic: not (v < first) and ((v < last) or active)
     v = version
+    v._prerelease = None
     first, last = get_version_range(part)
     active = (part.get(STATUS) == ACTIVE)
     if v.compare(first) < 0:

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -157,9 +157,12 @@ def is_compatible(active: bool, first: Version, last: Version,
     return active
 
 
-def parse_version1Category(s: str) -> List[str]:
-    cats = s.split(';')
-    return list(map(str.strip, cats))
+def _parse_version1Field(part, key) -> List[str]:
+    val = part.get(key)
+    if not val:
+        return []
+    raw_ids = val.split(';')
+    return list(map(str.strip, raw_ids))
 
 
 def get_mappings(part: dict, version: Version) -> Optional[List[PartId]]:
@@ -174,11 +177,11 @@ def get_mappings(part: dict, version: Version) -> Optional[List[PartId]]:
     kind = V1_KIND_MAP.get(loc)
     try:
         if kind == MapKind.TABLE:
-            ids = [part[V1_TABLE]]
+            ids = _parse_version1Field(part, V1_TABLE)
         elif kind == MapKind.ATTRIBUTE:
-            ids = [part[V1_VARIABLE]]
+            ids = _parse_version1Field(part, V1_VARIABLE)
         elif kind == MapKind.CATEGORY or is_bool_set(part):
-            ids = parse_version1Category(part[V1_CATEGORY])
+            ids = _parse_version1Field(part, V1_CATEGORY)
     except KeyError:
         return
     if len(list(filter(lambda id: id and id != '', ids))) == 0:

--- a/src/odm_validation/part_tables.py
+++ b/src/odm_validation/part_tables.py
@@ -172,8 +172,13 @@ def get_version_range(part: dict) -> (Version, Version):
 
 def is_compatible(part, version: Version) -> bool:
     """Returns True if part is compatible with `version`."""
-    # XXX: prerelease (like rc.3, etc.) must be stripped from `version`
-    # before compare, because `v2.0.0-rc.3` < `v.2.0.0`.
+    # XXX: prerelease (like rc.3, etc.) must be stripped from `version` before
+    # compare, because a version with a rc-suffix is seen as less than a
+    # version without it, and our ODM version is lagging behind the version of
+    # the parts (which don't have suffixes) in that sense, but we still want
+    # them to be equal.
+    # Example: (ODM version) 2.0.0-rc.3 < (part version) 2.0.0
+    #
     # logic: not (v < first) and ((v < last) or active)
     v = version
     v._prerelease = None

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -201,10 +201,10 @@ def is_primary_key(table_id: pt.TableId, attr: Part):
 
 def gen_conditional_schema(data: pt.PartData, ver: Version, rule_id: str,
                            gen_cerb_rules, pred: AttrPredicate):
-    # Helper function to generate a cerberus schema the implements an ODM
-    # validation rule
-    # Uses the passed pred argument to decide whether an entry should be
-    # created for an attribute in a table
+    """Helper function to generate a cerberus schema that implements an ODM
+    validation rule. Uses `pred` to decide whether an entry should be created
+    for an attribute in a table.
+    """
     schema = {}
     odm_key = None
     for table in table_items2(data):

--- a/src/odm_validation/rule_primitives.py
+++ b/src/odm_validation/rule_primitives.py
@@ -195,6 +195,10 @@ def is_mandatory(table_id: pt.TableId, attr: Part):
     return req_val == pt.MANDATORY
 
 
+def is_primary_key(table_id: pt.TableId, attr: Part):
+    return attr.get(table_id) == pt.ColumnKind.PK.value
+
+
 def gen_conditional_schema(data: pt.PartData, ver: Version, rule_id: str,
                            gen_cerb_rules, pred: AttrPredicate):
     # Helper function to generate a cerberus schema the implements an ODM
@@ -213,20 +217,6 @@ def gen_conditional_schema(data: pt.PartData, ver: Version, rule_id: str,
             cerb_rules = gen_cerb_rules(val_ctx)
             set_attr_schema(table_schema, data, table, attr, rule_id,
                             odm_key, cerb_rules, ver)
-        deep_update(schema, table_schema)
-    return schema
-
-
-def gen_global_schema(data: pt.PartData, ver: Version, rule_id: str,
-                      gen_cerb_rules):
-    schema = {}
-    cerb_rules = gen_cerb_rules(None)
-    for table in table_items2(data):
-        table_id = pt.get_partID(table)
-        table_schema = init_table_schema2(schema, data, table, ver)
-        for attr in data.table_data[table_id].attributes:
-            set_attr_schema(table_schema, data, table, attr, rule_id,
-                            None, cerb_rules, ver)
         deep_update(schema, table_schema)
     return schema
 

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -16,11 +16,11 @@ from rule_primitives import (
     attr_items,
     gen_cerb_rules_for_type,
     gen_conditional_schema,
-    gen_global_schema,
     gen_value_schema,
     get_catset_meta,
     get_table_meta,
     is_mandatory,
+    is_primary_key,
     parse_odm_val,
     table_items,
 )
@@ -90,7 +90,8 @@ def duplicate_entries_found():
         return {'unique': True}
 
     def gen_schema(data: pt.PartData, ver):
-        return gen_global_schema(data, ver, rule_id, gen_cerb_rules)
+        return gen_conditional_schema(data, ver, rule_id, gen_cerb_rules,
+                                      is_primary_key)
 
     return init_rule(rule_id, err, gen_cerb_rules, gen_schema)
 

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -3,13 +3,8 @@ This is the main module of the package. It contains functions for schema
 generation and data validation.
 """
 
-import os
-import re
-import sys
 from copy import deepcopy
 from itertools import groupby
-from os.path import join, normpath
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 # from pprint import pprint
 
@@ -29,23 +24,6 @@ from stdext import (
 from versions import __version__, parse_version
 
 
-def _get_latest_odm_version() -> str:
-    file_path = normpath(os.path.realpath(__file__))
-    root_dir = join(os.path.dirname(file_path), '../..')
-    dict_dir = join(root_dir, 'assets/dictionary')
-    versions = []
-    for dir_path in Path(dict_dir).glob('v*'):
-        dir_name = os.path.basename(dir_path)
-        if not (match := re.search('v(.+)', dir_name)):
-            continue
-        v = parse_version(match.group(1), verbose=False)
-        versions.append(str(v))
-    if len(versions) == 0:
-        sys.exit("failed to get latest ODM version")
-    versions.sort()
-    return versions[-1]
-
-
 def _gen_cerb_rule_map():
     # Generates a dictionary that maps a cerberus validation rule to the ODM
     # rule that uses it.
@@ -60,9 +38,6 @@ def _gen_cerb_rule_map():
                 break
     return result
 
-
-# public constants
-ODM_LATEST = _get_latest_odm_version()
 
 # private constants
 _KEY_RULES = _gen_cerb_rule_map()
@@ -310,7 +285,7 @@ def _generate_validation_schema_ext(parts, schema_version,
     }
 
 
-def generate_validation_schema(parts, schema_version=ODM_LATEST,
+def generate_validation_schema(parts, schema_version=pt.ODM_VERSION_STR,
                                schema_additions={}) -> Schema:
     return _generate_validation_schema_ext(parts, schema_version,
                                            schema_additions)
@@ -318,7 +293,7 @@ def generate_validation_schema(parts, schema_version=ODM_LATEST,
 
 def _validate_data_ext(schema: Schema,
                        data: dict,
-                       data_version: str = ODM_LATEST,
+                       data_version: str = pt.ODM_VERSION_STR,
                        rule_whitelist: List[str] = [],
                        ) -> reports.ValidationReport:
     """Validates `data` with `schema`, using Cerberus."""
@@ -360,6 +335,6 @@ def _validate_data_ext(schema: Schema,
 
 def validate_data(schema: Schema,
                   data: dict,
-                  data_version=ODM_LATEST,
+                  data_version=pt.ODM_VERSION_STR,
                   ) -> reports.ValidationReport:
     return _validate_data_ext(schema, data, data_version)

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -2,7 +2,7 @@ import unittest
 
 import common
 import part_tables as pt
-from part_tables import get_mappings
+from part_tables import get_mappings, is_compatible
 from validation import generate_validation_schema
 from versions import Version, parse_version
 # from pprint import pprint
@@ -18,28 +18,22 @@ def get_row(first: str, last: str, active: bool):
     }
 
 
-def part_is_compatible(part: pt.Part, version: Version) -> bool:
-    first, last = pt.get_version_range(part)
-    active: bool = part.get(pt.STATUS) == pt.ACTIVE
-    return pt.is_compatible(active, first, last, version)
-
-
 class TestVersionCompat(common.OdmTestCase):
     def test_same(self):
         row = get_row('1.0.0', '1.0.0', True)
-        self.assertTrue(part_is_compatible(row, parse_version('1.0.0')))
+        self.assertTrue(is_compatible(row, parse_version('1.0.0')))
 
     def test_eq_first(self):
         row = get_row('1.0.0', '2.0.0', False)
-        self.assertTrue(part_is_compatible(row, parse_version('1.0.0')))
+        self.assertTrue(is_compatible(row, parse_version('1.0.0')))
 
     def test_eq_last(self):
         row = get_row('1.0.0', '2.0.0', False)
-        self.assertFalse(part_is_compatible(row, parse_version('2.0.0')))
+        self.assertFalse(is_compatible(row, parse_version('2.0.0')))
 
     def test_incomplete(self):
         row = get_row('2', '2.0', True)
-        self.assertTrue(part_is_compatible(row, parse_version('2.0.')))
+        self.assertTrue(is_compatible(row, parse_version('2.0.')))
 
 
 class TestVersion1FieldsExist(common.OdmTestCase):

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -3,7 +3,9 @@ import unittest
 import common
 import part_tables as pt
 from part_tables import get_mappings
+from validation import generate_validation_schema
 from versions import Version, parse_version
+# from pprint import pprint
 
 common.unused_import_dummy = 1
 
@@ -74,6 +76,87 @@ class TestVersion1FieldsExist(common.OdmTestCase):
         id_list_fail = [get_mappings(p, v) for p in self.parts_fail]
         self.assertEqual(id_list_pass, [['a'], ['b'], ['c', 'd']])
         self.assertEqual(id_list_fail, [None, None, None])
+
+
+class TestVersion1Table(common.OdmTestCase):
+    parts = [
+        {
+            'partID': 'mynewtable',
+            'partType': 'table',
+            'version1Table': 'myoldtable',
+            'version1Location': 'tables',
+            'status': 'active',
+        },
+        {
+            'partID': 'mynewtable2',
+            'partType': 'table',
+            'version1Table': 'myoldtable2',
+            'version1Location': 'tables',
+            'status': 'active',
+        },
+        {
+            'partID': 'myoldpart',
+            'partType': 'attribute',
+            'dataType': 'integer',
+            'firstReleased': '1',
+            'lastUpdated': '2',
+            'status': 'depreciated',
+            'version1Table': 'myoldtable;myoldtable2',
+            'version1Location': 'variables',
+            'version1Variable': 'myoldpart',
+        }
+    ]
+
+    expected_schema = {
+        'myoldtable': {
+            'type': 'list',
+            'schema': {
+                'type': 'dict',
+                'schema': {'myoldpart': {
+                    'type': 'integer',
+                    'coerce': 'integer',
+                    'meta': [{
+                        'meta': [{
+                            'partID': 'myoldpart',
+                            'dataType': 'integer',
+                            'version1Location': 'variables',
+                            'version1Table': 'myoldtable;myoldtable2',
+                            'version1Variable': 'myoldpart'
+                            }],
+                        'ruleID': 'invalid_type'}],
+                }},
+                'meta': [{
+                    'partID': 'mynewtable',
+                    'partType': 'table',
+                    'version1Location': 'tables',
+                    'version1Table': 'myoldtable'}]}},
+        'myoldtable2': {
+            'type': 'list',
+            'schema': {
+                'type': 'dict',
+                'schema': {'myoldpart': {
+                    'type': 'integer',
+                    'coerce': 'integer',
+                    'meta': [{
+                        'meta': [{
+                            'partID': 'myoldpart',
+                            'dataType': 'integer',
+                            'version1Location': 'variables',
+                            'version1Table': 'myoldtable;myoldtable2',
+                            'version1Variable': 'myoldpart'
+                            }],
+                        'ruleID': 'invalid_type'}],
+                }},
+                'meta': [{
+                    'partID': 'mynewtable2',
+                    'partType': 'table',
+                    'version1Location': 'tables',
+                    'version1Table': 'myoldtable2'}]}}}
+
+    def test(self):
+        self.maxDiff = None
+        schema = generate_validation_schema(self.parts, '1.0.0')
+        self.assertDictEqual(self.expected_schema, schema['schema'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes the edge case where attributes only valid in v1 only has a table-reference in `version1Table`.