### PR TITLE
fix requirement install instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,13 +11,14 @@ commands:
 ```
 git clone https://github.com/Big-Life-Lab/PHES-ODM-Validation.git odm-validation
 cd odm-validation
+pip install -r ./requirements.txt
 pip install -e .
 ```
 
 Tests can be run with the following commands (after setting up a dev. env.):
 
 ```
-pip install ./tests/requirements.txt
+pip install -r ./tests/requirements.txt
 python -m unittest discover ./tests
 ```
 


### PR DESCRIPTION
Requirements don't seem to be installed by the normal install command, and the test requirement command was wrong.