### PR TITLE
add batching of coercion and validation

### DIFF
--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -12,7 +12,8 @@ from cerberus.errors import ErrorDefinition
 import part_tables as pt
 import reports
 from rules import COERCION_RULE_ID
-from part_tables import Row
+from part_tables import Dataset, Row
+from schemas import CerberusSchema
 from stdext import (
     inc,
     parse_datetime,
@@ -82,7 +83,7 @@ class ContextualCoercer(Validator):
                     del schema[field]
         return result
 
-    def coerce(self, document, schema) -> Optional[dict]:
+    def coerce(self, document: Dataset, schema: CerberusSchema) -> Dataset:
         # Coercion is performed by validating using a coercion-only schema.
         # Native cerberus normalization can't be used because it doesn't
         # provide context. Coercions are kept track of using `_config`.

--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 from copy import deepcopy
 # from pprint import pprint
 
@@ -11,11 +11,11 @@ from cerberus.errors import ErrorDefinition
 
 import part_tables as pt
 import reports
+from reports import get_row_num
 from rules import COERCION_RULE_ID
 from part_tables import Dataset, Row
 from schemas import CerberusSchema
 from stdext import (
-    inc,
     parse_datetime,
     parse_int,
     type_name,
@@ -83,7 +83,8 @@ class ContextualCoercer(Validator):
                     del schema[field]
         return result
 
-    def coerce(self, document: Dataset, schema: CerberusSchema) -> Dataset:
+    def coerce(self, document: Dataset, schema: CerberusSchema,
+               offset: int) -> Dataset:
         # Coercion is performed by validating using a coercion-only schema.
         # Native cerberus normalization can't be used because it doesn't
         # provide context. Coercions are kept track of using `_config`.
@@ -95,6 +96,7 @@ class ContextualCoercer(Validator):
         coercion_schema = ContextualCoercer._extract_coercion_schema(schema)
         self.schema = coercion_schema
         self._config["coerced_document"] = deepcopy(document)
+        self._config["offset"] = offset
         if not super().validate(document):
             logging.error(self.errors, stack_info=True)
         return self._config["coerced_document"]
@@ -108,6 +110,7 @@ class ContextualCoercer(Validator):
             return
         if type_class is float and isinstance(orig_value, int):
             return
+        offset = self._config['offset']
         table = self.document_path[0]
         row_ix = self.document_path[1]
         row = self.document
@@ -118,7 +121,7 @@ class ContextualCoercer(Validator):
             column_id=field,
             column_meta=column_meta,
             rows=[row],
-            row_numbers=[inc(row_ix)],
+            row_numbers=[get_row_num(row_ix, offset)],
             table_id=table,
             value=orig_value,
         )
@@ -144,7 +147,7 @@ DateStr = str
 TableId = str
 PrimaryKey = Tuple[pt.PartId, DateStr]
 TableKey = Tuple[TableId, PrimaryKey]
-Index = int
+RowNum = int
 
 
 @dataclass
@@ -162,13 +165,14 @@ class UniqueRuleState:
     """State for the 'unique' rule."""
     def __init__(self):
         self.table_keys: Dict[TableId, Set[PrimaryKey]] = defaultdict(set)
-        self.tablekey_rows: Dict[TableKey, (Index, Row)] = {}
+        self.tablekey_rows: Dict[TableKey, (RowNum, Row)] = {}
         self.tablekey_errors: Dict[TableKey, AggregatedError] = \
             defaultdict(AggregatedError)
 
 
 class ErrorState:
     def __init__(self):
+        self.offset = 0
         self.aggregated_errors: List[AggregatedError] = []
 
 
@@ -210,9 +214,11 @@ class OdmValidator(Validator):
         # the primary key (pk) is a compound key of partID and lastUpdated
         if not constraint:
             return
+        offset = self.error_state.offset
         table_id = self.document_path[0]
-        row_ix = self.document_path[1]
         row = self.document
+        row_ix = self.document_path[1]
+        row_num = get_row_num(row_ix, offset)
         lastUpdated = row.get('lastUpdated', '') or ''
         assert isinstance(lastUpdated, str)
         pk = (str(value).strip(), lastUpdated.strip())
@@ -222,24 +228,25 @@ class OdmValidator(Validator):
         if pk in primary_keys:
             err = state.tablekey_errors.get(tablekey)
             if not err:
-                (first_ix, first_row) = state.tablekey_rows[tablekey]
+                (first_row_num, first_row) = state.tablekey_rows[tablekey]
                 err = AggregatedError(
                     cerb_rule='unique',
                     table_id=table_id,
                     column_id=field,
-                    row_numbers=[inc(first_ix)],
+                    row_numbers=[first_row_num],
                     rows=[first_row],
                     column_meta=self.schema[field].get('meta'),
                     value=pk[0]
                 )
                 state.tablekey_errors[tablekey] = err
-            err.row_numbers.append(inc(row_ix))
+            err.row_numbers.append(row_num)
             err.rows.append(row)
         else:
-            state.tablekey_rows[tablekey] = (row_ix, row)
+            state.tablekey_rows[tablekey] = (row_num, row)
             primary_keys.add(pk)
 
-    def validate(self, *args, **kwargs) -> bool:
+    def validate(self, offset: int, *args, **kwargs) -> bool:
+        self.error_state.offset = offset
         self.error_state.aggregated_errors.clear()
         result = super().validate(*args, **kwargs)
         self.error_state.aggregated_errors += \

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -52,6 +52,12 @@ def _fmt_list(items: list) -> str:
         return str(items[0])
 
 
+def get_row_num(row_index: int, offset: int) -> int:
+    """Returns the spreadsheet row number of `row_index` plus `offset`,
+    converted to a one-indexed number."""
+    return offset + row_index + 1
+
+
 def _fmt_value(val: Any) -> Any:
     # needed to avoid the default `datetime.datetime(year, month, day, ...)`
     if isinstance(val, datetime.date) or isinstance(val, datetime.datetime):

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -44,6 +44,7 @@ def _gen_cerb_rule_map():
 
 
 # private constants
+_BATCH_SIZE = 100
 _KEY_RULES = _gen_cerb_rule_map()
 
 
@@ -313,6 +314,7 @@ def _validate_data_ext(schema: Schema,
                        data_version: str = pt.ODM_VERSION_STR,
                        rule_whitelist: List[str] = [],
                        on_progress: OnProgress = None,
+                       batch_size=_BATCH_SIZE,
                        ) -> reports.ValidationReport:
     """Validates `data` with `schema`, using Cerberus."""
     # `rule_whitelist` determines which rules/errors are triggered during
@@ -334,11 +336,10 @@ def _validate_data_ext(schema: Schema,
         'the table names as keys.')
 
     def batch_table_data(action, table_id, table_data):
-        BATCH_SIZE = 100
         total = len(table_data)
         offset = 0
         while offset < total:
-            n = min(total - offset, BATCH_SIZE)
+            n = min(total - offset, batch_size)
             first = offset
             last = offset + n
             batch_data = {table_id: table_data[first:last]}

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -3,9 +3,10 @@ This is the main module of the package. It contains functions for schema
 generation and data validation.
 """
 
+from collections import defaultdict
 from copy import deepcopy
 from itertools import groupby
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 # from pprint import pprint
 
 from cerberusext import ContextualCoercer, OdmValidator
@@ -13,7 +14,7 @@ from cerberusext import ContextualCoercer, OdmValidator
 import part_tables as pt
 import reports
 import rules
-from reports import ErrorKind
+from reports import ErrorKind, get_row_num
 from rules import Rule, ruleset
 from schemas import CerberusSchema, Schema, init_table_schema
 from stdext import (
@@ -127,12 +128,14 @@ def _gen_error_entry(cerb_rule, table_id, column_id, value, row_numbers,
 
 
 def _gen_cerb_error_entry(e, row, schema: CerberusSchema,
-                          rule_whitelist: List[str]) -> Optional[dict]:
+                          rule_whitelist: List[str], offset: int
+                          ) -> Optional[dict]:
     cerb_rule = e.schema_path[-1]
-    (table_id, row_index, column_id) = e.document_path
+    (table_id, _, column_id) = e.document_path
+    row_index = e.document_path[1]
     schema_column = schema[table_id]['schema']['schema'][column_id]
     column_meta = schema_column.get('meta', [])
-    row_numbers = [row_index + 1]
+    row_numbers = [get_row_num(row_index, offset)]
     rows = [row]
     return _gen_error_entry(
         cerb_rule,
@@ -149,7 +152,7 @@ def _gen_cerb_error_entry(e, row, schema: CerberusSchema,
 
 
 def _gen_aggregated_error_entry(agg_error,
-                                rule_whitelist: List[str]
+                                rule_whitelist: List[str],
                                 ) -> Optional[dict]:
     return _gen_error_entry(
         agg_error.cerb_rule,
@@ -212,17 +215,12 @@ def _filter_errors(errors):
     return result
 
 
-def _coerce_data(data: TableDataset, schema: CerberusSchema, warnings, errors
-                 ) -> TableDataset:
-    coercer = ContextualCoercer(warnings=warnings, errors=errors)
-    return coercer.coerce(data, schema)
-
-
 def _strip_coerce_rules(cerb_schema):
     return strip_dict_key(deepcopy(cerb_schema), 'coerce')
 
 
-def _map_errors(cerb_errors, schema, rule_whitelist):
+def _map_cerb_errors(cerb_errors, schema, rule_whitelist, offset: int):
+    "Returns (errors, warnings)."
     errors = []
     warnings = []
     for table_error in cerb_errors:
@@ -232,7 +230,7 @@ def _map_errors(cerb_errors, schema, rule_whitelist):
                 for attr_errors in e.info:
                     for e in attr_errors:
                         entry = _gen_cerb_error_entry(e, row, schema,
-                                                      rule_whitelist)
+                                                      rule_whitelist, offset)
                         if not entry:
                             continue
                         if 'warningType' in entry:
@@ -306,10 +304,15 @@ def generate_validation_schema(parts, schema_version=pt.ODM_VERSION_STR,
                                            schema_additions)
 
 
+# OnProgress(action, table_id, processed, total)
+OnProgress = Callable[[str, str, int, int], None]
+
+
 def _validate_data_ext(schema: Schema,
                        data: TableDataset,
                        data_version: str = pt.ODM_VERSION_STR,
                        rule_whitelist: List[str] = [],
+                       on_progress: OnProgress = None,
                        ) -> reports.ValidationReport:
     """Validates `data` with `schema`, using Cerberus."""
     # `rule_whitelist` determines which rules/errors are triggered during
@@ -330,14 +333,41 @@ def _validate_data_ext(schema: Schema,
         '`data` must be a dict. Remember to wrap the datasets in a dict with '
         'the table names as keys.')
 
-    coerced_data = _coerce_data(data, coercion_schema, warnings, errors)
+    def batch_table_data(action, table_id, table_data):
+        BATCH_SIZE = 100
+        total = len(table_data)
+        offset = 0
+        while offset < total:
+            n = min(total - offset, BATCH_SIZE)
+            first = offset
+            last = offset + n
+            batch_data = {table_id: table_data[first:last]}
+            yield (batch_data, offset)
+            offset += n
+            if on_progress:
+                on_progress(action, table_id, offset, total)
 
-    v = OdmValidator.new()
+    coerced_data = defaultdict(list)
+    coercer = ContextualCoercer(warnings=warnings, errors=errors)
+    for table_id, table_data in data.items():
+        for batch in batch_table_data('coercing', table_id, table_data):
+            batch_data, offset = batch
+            coerce_result = coercer.coerce(batch_data, coercion_schema,
+                                           offset)
+            coerced_data[table_id] += coerce_result[table_id]
+
     validation_schema = _strip_coerce_rules(coercion_schema)
-    if not v.validate(coerced_data, validation_schema):
-        e, w = _map_errors(v._errors, validation_schema, rule_whitelist)
-        warnings += w
-        errors += e
+    for table_id, table_data in coerced_data.items():
+        v = OdmValidator.new()
+        for batch in batch_table_data('validating', table_id, table_data):
+            batch_data, offset = batch
+            v._errors.clear()
+            if v.validate(offset, batch_data, validation_schema):
+                continue
+            e, w = _map_cerb_errors(v._errors, validation_schema,
+                                    rule_whitelist, offset)
+            errors += e
+            warnings += w
         errors += _map_aggregated_errors(v.error_state.aggregated_errors,
                                          rule_whitelist)
 

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -24,6 +24,9 @@ from stdext import (
 from versions import __version__, parse_version
 
 
+TableDataset = Dict[pt.TableId, pt.Dataset]
+
+
 def _gen_cerb_rule_map():
     # Generates a dictionary that maps a cerberus validation rule to the ODM
     # rule that uses it.
@@ -209,7 +212,8 @@ def _filter_errors(errors):
     return result
 
 
-def _coerce_data(data, schema, warnings, errors):
+def _coerce_data(data: TableDataset, schema: CerberusSchema, warnings, errors
+                 ) -> TableDataset:
     coercer = ContextualCoercer(warnings=warnings, errors=errors)
     return coercer.coerce(data, schema)
 
@@ -303,7 +307,7 @@ def generate_validation_schema(parts, schema_version=pt.ODM_VERSION_STR,
 
 
 def _validate_data_ext(schema: Schema,
-                       data: dict,
+                       data: TableDataset,
                        data_version: str = pt.ODM_VERSION_STR,
                        rule_whitelist: List[str] = [],
                        ) -> reports.ValidationReport:
@@ -349,7 +353,7 @@ def _validate_data_ext(schema: Schema,
 
 
 def validate_data(schema: Schema,
-                  data: dict,
+                  data: TableDataset,
                   data_version=pt.ODM_VERSION_STR,
                   ) -> reports.ValidationReport:
     return _validate_data_ext(schema, data, data_version)

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -119,7 +119,7 @@ class TestCoercion(common.OdmTestCase):
     def test_coerce(self):
         warnings = []
         v = ContextualCoercer(warnings=warnings)
-        result = v.coerce(data, cerb_schema)
+        result = v.coerce(data, cerb_schema, 0)
         self.assertEqual(coerced_data, result)
         self.assertEqual(expected_coercion_warnings, warnings)
 

--- a/tests/test_duplicate_entries_found.py
+++ b/tests/test_duplicate_entries_found.py
@@ -65,8 +65,10 @@ class TestDuplicateEntriesFound(common.OdmTestCase):
 
     @parameterized.expand(param_range(1, 3))
     def test_failing_datasets(self, i):
+        data = self.assets.data_fail[i]
         report = _validate_data_ext(schema=self.assets.schemas[2],
-                                    data=self.assets.data_fail[i])
+                                    data=data,
+                                    batch_size=(max(1, len(data) // 2)))
         expected = self.assets.error_report[i]
         self.assertReportEqual(expected, report)
 


### PR DESCRIPTION
Cerberus can't handle big datasets. This fixes that by splitting up the workload into smaller batches.