### PR TITLE
skip coercion/validation of empty values

### DIFF
--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -102,10 +102,10 @@ class ContextualCoercer(Validator):
         entry = reports.gen_coercion_error(ctx, kind)
         self._config[kind.value + 's'].append(entry)
 
-    def _set_value(self, field, orig_value, type_class):
-        if isinstance(orig_value, type_class):
+    def _set_value(self, field, value, type_class):
+        if isinstance(value, type_class):
             return
-        if type_class is float and isinstance(orig_value, int):
+        if type_class is float and isinstance(value, int):
             return
         table = self.document_path[0]
         row_ix = self.document_path[1]
@@ -119,14 +119,13 @@ class ContextualCoercer(Validator):
             rows=[row],
             row_numbers=[inc(row_ix)],
             table_id=table,
-            value=orig_value,
+            value=value,
         )
         try:
-            value = _convert_value(orig_value, type_class)
-            self._config["coerced_document"][table][row_ix][field] = value
+            new_value = _convert_value(value, type_class)
+            self._config["coerced_document"][table][row_ix][field] = new_value
             self._log_coercion(reports.ErrorKind.WARNING, ctx)
         except (ArithmeticError, ValueError):
-            value = orig_value
             self._log_coercion(reports.ErrorKind.ERROR, ctx)
 
     def _check_with_datetime(self, field, value):

--- a/src/odm_validation/cerberusext.py
+++ b/src/odm_validation/cerberusext.py
@@ -103,6 +103,9 @@ class ContextualCoercer(Validator):
         self._config[kind.value + 's'].append(entry)
 
     def _set_value(self, field, value, type_class):
+        # ignore empty values, they can't be coerced anyway
+        if not value:
+            return
         if isinstance(value, type_class):
             return
         if type_class is float and isinstance(value, int):

--- a/src/odm_validation/validation.py
+++ b/src/odm_validation/validation.py
@@ -99,6 +99,9 @@ def _gen_error_entry(cerb_rule, table_id, column_id, value, row_numbers,
                      rows, column_meta, rule_whitelist: List[str],
                      constraint=None, schema_column=None,
                      ) -> Optional[dict]:
+    if not value and cerb_rule == 'type':
+        return
+
     rule = _get_rule_for_cerb_key(cerb_rule, column_meta)
     if len(rule_whitelist) > 0 and rule.id not in rule_whitelist:
         return


### PR DESCRIPTION
An empty string can't be coerced into a number or type-validated as a datetime, etc. The validation was flooded by these kind of errors, which is fixed here.