### PR TITLE
tools/validate: skip empty lines

### DIFF
--- a/tools/validate_xlsx.py
+++ b/tools/validate_xlsx.py
@@ -25,7 +25,7 @@ def import_xlsx(src_file, dst_dir) -> List[str]:
     "Returns list of imported csv files."
     result = []
     print(f'importing {basename(src_file)}')
-    xl = Xlsx2csv(src_file)
+    xl = Xlsx2csv(src_file, skip_empty_lines=True)
     for sheet in xl.workbook.sheets:
         name = sheet['name']
         csv_path = join(dst_dir, name + '.csv')


### PR DESCRIPTION
Some excel files may have stray characters on a very high row number, which will cause very slow validation and a bunch of extra 'empty-value' errors.

One potential issue with this is that the row-numbers after empty rows will be wrong. This can be addressed in #143/#148, which already will fix row numbers.