### PR TITLE
rewrite report error messages for consistency

### DIFF
--- a/assets/validation-rules/duplicate-entries-found/error-report-1.json
+++ b/assets/validation-rules/duplicate-entries-found/error-report-1.json
@@ -22,7 +22,7 @@
                     "addresses": "pK"
                 }
             ],
-            "message": "Duplicate entries found in rows 1,2 with primary key column addId and primary key value 1 in table addresses"
+            "message": "duplicate_entries_found rule violated in table addresses, column addId, row 1,2: Duplicate entries found with primary key value \"1\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/duplicate-entries-found/error-report-1.json
+++ b/assets/validation-rules/duplicate-entries-found/error-report-1.json
@@ -22,7 +22,7 @@
                     "addresses": "pK"
                 }
             ],
-            "message": "duplicate_entries_found rule violated in table addresses, column addId, row 1,2: Duplicate entries found with primary key value \"1\""
+            "message": "duplicate_entries_found rule violated in table addresses, column addId, rows 1,2: Duplicate entries found with primary key value \"1\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/duplicate-entries-found/error-report-2.json
+++ b/assets/validation-rules/duplicate-entries-found/error-report-2.json
@@ -22,7 +22,7 @@
                     "addresses": "pK"
                 }
             ],
-            "message": "Duplicate entries found in rows 2,3 with primary key column addId and primary key value 1 in table addresses"
+            "message": "duplicate_entries_found rule violated in table addresses, column addId, row 2,3: Duplicate entries found with primary key value \"1\""
         },
         {
             "errorType": "duplicate_entries_found",
@@ -46,7 +46,7 @@
                     "addresses": "pK"
                 }
             ],
-            "message": "Duplicate entries found in rows 5,6 with primary key column addId and primary key value 2 in table addresses"
+            "message": "duplicate_entries_found rule violated in table addresses, column addId, row 5,6: Duplicate entries found with primary key value \"2\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/duplicate-entries-found/error-report-2.json
+++ b/assets/validation-rules/duplicate-entries-found/error-report-2.json
@@ -22,7 +22,7 @@
                     "addresses": "pK"
                 }
             ],
-            "message": "duplicate_entries_found rule violated in table addresses, column addId, row 2,3: Duplicate entries found with primary key value \"1\""
+            "message": "duplicate_entries_found rule violated in table addresses, column addId, rows 2,3: Duplicate entries found with primary key value \"1\""
         },
         {
             "errorType": "duplicate_entries_found",
@@ -46,7 +46,7 @@
                     "addresses": "pK"
                 }
             ],
-            "message": "duplicate_entries_found rule violated in table addresses, column addId, row 5,6: Duplicate entries found with primary key value \"2\""
+            "message": "duplicate_entries_found rule violated in table addresses, column addId, rows 5,6: Duplicate entries found with primary key value \"2\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/greater-than-max-length/error-report.json
+++ b/assets/validation-rules/greater-than-max-length/error-report.json
@@ -17,7 +17,7 @@
                     "contacts": "header"
                 }
             ],
-            "message": "Value 123-456-111 in row 1 in column phone in table contacts has length 11 which is greater than the max length of 10"
+            "message": "greater_than_max_length rule violated in table contacts, column phone, row 1: Value \"123-456-111\" has length 11 which is greater than the max length of \"10\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/greater-than-max-value/error-report-1.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-1.json
@@ -18,7 +18,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 91 in row 1 in column geoLat in table sites is greater than the allowable maximum value of 90"
+            "message": "greater_than_max_value rule violated in table sites, column geoLat, row 1: Value \"91\" is greater than the allowable maximum value of \"90\""
         },
         {
             "errorType": "greater_than_max_value",
@@ -38,7 +38,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 90.2 in row 1 in column geoLong in table sites is greater than the allowable maximum value of 90.15"
+            "message": "greater_than_max_value rule violated in table sites, column geoLong, row 1: Value \"90.2\" is greater than the allowable maximum value of \"90.15\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/greater-than-max-value/error-report-2.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-2.json
@@ -18,7 +18,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 91 in row 1 in column geoLat in table sites is greater than the allowable maximum value of 90"
+            "message": "greater_than_max_value rule violated in table sites, column geoLat, row 1: Value \"91\" is greater than the allowable maximum value of \"90\""
         },
         {
             "errorType": "greater_than_max_value",
@@ -38,7 +38,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 90.2 in row 1 in column geoLong in table sites is greater than the allowable maximum value of 90.15"
+            "message": "greater_than_max_value rule violated in table sites, column geoLong, row 1: Value \"90.2\" is greater than the allowable maximum value of \"90.15\""
         }
     ],
     "warnings": [
@@ -61,7 +61,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 91 in row 1 in column geoLat in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLat, row 1: Value \"91\" is a string and was coerced into a number"
         },
         {
             "warningType": "_coercion",
@@ -82,7 +82,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 90.2 in row 1 in column geoLong in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLong, row 1: Value \"90.2\" is a string and was coerced into a number"
         }
     ]
 }

--- a/assets/validation-rules/greater-than-max-value/error-report-3.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-3.json
@@ -19,7 +19,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value a in row 1 in column geoLat in table sites cannot be coerced into a number"
+            "message": "_coercion rule violated in table sites, column geoLat, row 1: Value \"a\" cannot be coerced into a number"
         },
         {
             "errorType": "_coercion",
@@ -40,7 +40,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value b in row 1 in column geoLong in table sites cannot be coerced into a number"
+            "message": "_coercion rule violated in table sites, column geoLong, row 1: Value \"b\" cannot be coerced into a number"
         }
     ],
     "warnings": []

--- a/assets/validation-rules/greater-than-max-value/error-report-4.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-4.json
@@ -17,7 +17,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2024-12-30 00:00:00 in row 1 in column lastEdited in table sites is greater than the allowable maximum value of 2024-01-01 00:00:00"
+            "message": "greater_than_max_value rule violated in table sites, column lastEdited, row 1: Value \"2024-12-30 00:00:00\" is greater than the allowable maximum value of \"2024-01-01 00:00:00\""
         }
     ],
     "warnings": [
@@ -39,7 +39,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2024-12-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "_coercion rule triggered in table sites, column lastEdited, row 1: Value \"2024-12-30\" is a string and was coerced into a datetime"
         }
     ]
 }

--- a/assets/validation-rules/greater-than-max-value/error-report-pass-2.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-pass-2.json
@@ -20,7 +20,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 89 in row 1 in column geoLat in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLat, row 1: Value \"89\" is a string and was coerced into a number"
         },
         {
             "warningType": "_coercion",
@@ -41,7 +41,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 90.1 in row 1 in column geoLong in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLong, row 1: Value \"90.1\" is a string and was coerced into a number"
         }
     ]
 }

--- a/assets/validation-rules/greater-than-max-value/error-report-pass-4.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-pass-4.json
@@ -19,7 +19,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2023-01-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "_coercion rule triggered in table sites, column lastEdited, row 1: Value \"2023-01-30\" is a string and was coerced into a datetime"
         },
         {
             "warningType": "_coercion",
@@ -39,7 +39,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2023-01-30T00:00:00 in row 2 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "_coercion rule triggered in table sites, column lastEdited, row 2: Value \"2023-01-30T00:00:00\" is a string and was coerced into a datetime"
         }
     ]
 }

--- a/assets/validation-rules/invalid-category/error-report.json
+++ b/assets/validation-rules/invalid-category/error-report.json
@@ -32,7 +32,7 @@
                     "catSetID": "collectCat"
                 }
             ],
-            "message": "Invalid category flow found in row 1 for column coll in table samples"
+            "message": "invalid_category rule violated in table samples, column coll, row 1: Invalid category \"flow\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/invalid-type/bool-error-report-1.json
+++ b/assets/validation-rules/invalid-type/bool-error-report-1.json
@@ -17,7 +17,7 @@
                     "measures": "header"
                 }
             ],
-            "message": "Column reportable in row 1 in table measures is a boolean but has value Yes. Allowed values are false/true."
+            "message": "invalid_type rule violated in table measures, column reportable, row 1: Column reportable is a boolean but has value \"Yes\". Allowed values are false/true."
         }
     ],
     "warnings": []

--- a/assets/validation-rules/invalid-type/bool-error-report-2.json
+++ b/assets/validation-rules/invalid-type/bool-error-report-2.json
@@ -17,7 +17,7 @@
                     "measures": "header"
                 }
             ],
-            "message": "Column reportable in row 1 in table measures is a boolean but has value True. Allowed values are false/true."
+            "message": "invalid_type rule violated in table measures, column reportable, row 1: Column reportable is a boolean but has value \"True\". Allowed values are false/true."
         }
     ],
     "warnings": []

--- a/assets/validation-rules/invalid-type/datetime-error-report-1.json
+++ b/assets/validation-rules/invalid-type/datetime-error-report-1.json
@@ -17,7 +17,7 @@
                     "measures": "header"
                 }
             ],
-            "message": "Column reportDate in row 1 in table measures is a datetime with value a that has an unsupported datetime format. Allowed values are ISO 8601 standard full dates, full dates and times, or full dates and times with timezone."
+            "message": "invalid_type rule violated in table measures, column reportDate, row 1: Column reportDate is a datetime but has value \"a\". Allowed values are ISO 8601 standard full dates, full dates and times, or full dates and times with timezone."
         },
         {
             "errorType": "invalid_type",
@@ -36,7 +36,7 @@
                     "measures": "header"
                 }
             ],
-            "message": "Column reportDate in row 2 in table measures is a datetime with value 2022 that has an unsupported datetime format. Allowed values are ISO 8601 standard full dates, full dates and times, or full dates and times with timezone."
+            "message": "invalid_type rule violated in table measures, column reportDate, row 2: Column reportDate is a datetime but has value \"2022\". Allowed values are ISO 8601 standard full dates, full dates and times, or full dates and times with timezone."
         }
     ],
     "warnings": []

--- a/assets/validation-rules/invalid-type/float-error-report-1.json
+++ b/assets/validation-rules/invalid-type/float-error-report-1.json
@@ -17,7 +17,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value a in row 1 in column geoLat in table sites has type string but should be of type float or coercable into a float"
+            "message": "invalid_type rule violated in table sites, column geoLat, row 1: Value \"a\" has type string but should be of type float or coercable into a float"
         }
     ],
     "warnings": []

--- a/assets/validation-rules/invalid-type/integer-error-report-1.json
+++ b/assets/validation-rules/invalid-type/integer-error-report-1.json
@@ -17,7 +17,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 1.23 in row 1 in column geoLat in table sites has type float but should be of type integer or coercable into a integer"
+            "message": "invalid_type rule violated in table sites, column geoLat, row 1: Value \"1.23\" has type float but should be of type integer or coercable into a integer"
         }
     ],
     "warnings": []

--- a/assets/validation-rules/invalid-type/integer-error-report-2.json
+++ b/assets/validation-rules/invalid-type/integer-error-report-2.json
@@ -17,7 +17,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value a in row 1 in column geoLat in table sites has type string but should be of type integer or coercable into a integer"
+            "message": "invalid_type rule violated in table sites, column geoLat, row 1: Value \"a\" has type string but should be of type integer or coercable into a integer"
         },
         {
             "errorType": "invalid_type",
@@ -36,7 +36,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 1.01 in row 2 in column geoLat in table sites has type string but should be of type integer or coercable into a integer"
+            "message": "invalid_type rule violated in table sites, column geoLat, row 2: Value \"1.01\" has type string but should be of type integer or coercable into a integer"
         }
     ],
     "warnings": []

--- a/assets/validation-rules/less-than-min-length/error-report.json
+++ b/assets/validation-rules/less-than-min-length/error-report.json
@@ -17,7 +17,7 @@
                     "contacts": "header"
                 }
             ],
-            "message": "Value 123-456-1 in row 1 in column phone in table contacts has length 9 which is less than the min length of 10"
+            "message": "less_than_min_length rule violated in table contacts, column phone, row 1: Value \"123-456-1\" has length 9 which is less than the min length of \"10\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/less-than-min-value/error-report-1.json
+++ b/assets/validation-rules/less-than-min-value/error-report-1.json
@@ -18,7 +18,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -91 in row 1 in column geoLat in table sites is less than the allowable minimum value of -90"
+            "message": "less_than_min_value rule violated in table sites, column geoLat, row 1: Value \"-91\" is less than the allowable minimum value of \"-90\""
         },
         {
             "errorType": "less_than_min_value",
@@ -38,7 +38,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -90.2 in row 1 in column geoLong in table sites is less than the allowable minimum value of -90.15"
+            "message": "less_than_min_value rule violated in table sites, column geoLong, row 1: Value \"-90.2\" is less than the allowable minimum value of \"-90.15\""
         }
     ],
     "warnings": []

--- a/assets/validation-rules/less-than-min-value/error-report-2.json
+++ b/assets/validation-rules/less-than-min-value/error-report-2.json
@@ -18,7 +18,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -91 in row 1 in column geoLat in table sites is less than the allowable minimum value of -90"
+            "message": "less_than_min_value rule violated in table sites, column geoLat, row 1: Value \"-91\" is less than the allowable minimum value of \"-90\""
         },
         {
             "errorType": "less_than_min_value",
@@ -38,7 +38,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -90.2 in row 1 in column geoLong in table sites is less than the allowable minimum value of -90.15"
+            "message": "less_than_min_value rule violated in table sites, column geoLong, row 1: Value \"-90.2\" is less than the allowable minimum value of \"-90.15\""
         }
     ],
     "warnings": [
@@ -61,7 +61,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -91 in row 1 in column geoLat in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLat, row 1: Value \"-91\" is a string and was coerced into a number"
         },
         {
             "warningType": "_coercion",
@@ -82,7 +82,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -90.2 in row 1 in column geoLong in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLong, row 1: Value \"-90.2\" is a string and was coerced into a number"
         }
     ]
 }

--- a/assets/validation-rules/less-than-min-value/error-report-3.json
+++ b/assets/validation-rules/less-than-min-value/error-report-3.json
@@ -19,7 +19,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value a in row 1 in column geoLat in table sites cannot be coerced into a number"
+            "message": "_coercion rule violated in table sites, column geoLat, row 1: Value \"a\" cannot be coerced into a number"
         },
         {
             "errorType": "_coercion",
@@ -40,7 +40,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value b in row 1 in column geoLong in table sites cannot be coerced into a number"
+            "message": "_coercion rule violated in table sites, column geoLong, row 1: Value \"b\" cannot be coerced into a number"
         }
     ],
     "warnings": []

--- a/assets/validation-rules/less-than-min-value/error-report-4.json
+++ b/assets/validation-rules/less-than-min-value/error-report-4.json
@@ -17,7 +17,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2022-12-30 00:00:00 in row 1 in column lastEdited in table sites is less than the allowable minimum value of 2023-01-01 00:00:00"
+            "message": "less_than_min_value rule violated in table sites, column lastEdited, row 1: Value \"2022-12-30 00:00:00\" is less than the allowable minimum value of \"2023-01-01 00:00:00\""
         }
     ],
     "warnings": [
@@ -39,7 +39,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2022-12-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "_coercion rule triggered in table sites, column lastEdited, row 1: Value \"2022-12-30\" is a string and was coerced into a datetime"
         }
     ]
 }

--- a/assets/validation-rules/less-than-min-value/error-report-pass-2.json
+++ b/assets/validation-rules/less-than-min-value/error-report-pass-2.json
@@ -20,7 +20,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -89 in row 1 in column geoLat in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLat, row 1: Value \"-89\" is a string and was coerced into a number"
         },
         {
             "warningType": "_coercion",
@@ -41,7 +41,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value -90 in row 1 in column geoLong in table sites is a string and was coerced into a number"
+            "message": "_coercion rule triggered in table sites, column geoLong, row 1: Value \"-90\" is a string and was coerced into a number"
         }
     ]
 }

--- a/assets/validation-rules/less-than-min-value/error-report-pass-4.json
+++ b/assets/validation-rules/less-than-min-value/error-report-pass-4.json
@@ -19,7 +19,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2023-01-30 in row 1 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "_coercion rule triggered in table sites, column lastEdited, row 1: Value \"2023-01-30\" is a string and was coerced into a datetime"
         },
         {
             "warningType": "_coercion",
@@ -39,7 +39,7 @@
                     "sites": "header"
                 }
             ],
-            "message": "Value 2023-01-30T00:00:00 in row 2 in column lastEdited in table sites is a string and was coerced into a datetime"
+            "message": "_coercion rule triggered in table sites, column lastEdited, row 2: Value \"2023-01-30T00:00:00\" is a string and was coerced into a datetime"
         }
     ]
 }

--- a/assets/validation-rules/missing-mandatory-column/error-report.json
+++ b/assets/validation-rules/missing-mandatory-column/error-report.json
@@ -15,7 +15,7 @@
                     "addressesRequired": "mandatory"
                 }
             ],
-            "message": "Missing mandatory column addID in table addresses in row number 1"
+            "message": "missing_mandatory_column rule violated in table addresses, column addID, row 1: Missing mandatory column addID"
         }
     ],
     "warnings": []

--- a/assets/validation-rules/missing-values-found/error-report-1.json
+++ b/assets/validation-rules/missing-values-found/error-report-1.json
@@ -17,7 +17,7 @@
                     "sitesRequired": "mandatory"
                 }
             ],
-            "message": "Mandatory column geoLat in table sites has a missing value in row 1"
+            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value"
         }
     ],
     "errors": []

--- a/assets/validation-rules/missing-values-found/error-report-1.json
+++ b/assets/validation-rules/missing-values-found/error-report-1.json
@@ -17,7 +17,7 @@
                     "sitesRequired": "mandatory"
                 }
             ],
-            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value"
+            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Empty string found"
         }
     ],
     "errors": []

--- a/assets/validation-rules/missing-values-found/error-report-2.json
+++ b/assets/validation-rules/missing-values-found/error-report-2.json
@@ -17,7 +17,7 @@
                     "sitesRequired": "mandatory"
                 }
             ],
-            "message": "Mandatory column geoLat in table sites has a missing value in row 1"
+            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value"
         }
     ],
     "errors": []

--- a/assets/validation-rules/missing-values-found/error-report-2.json
+++ b/assets/validation-rules/missing-values-found/error-report-2.json
@@ -17,7 +17,7 @@
                     "sitesRequired": "mandatory"
                 }
             ],
-            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value"
+            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value \"  \""
         }
     ],
     "errors": []

--- a/assets/validation-rules/missing-values-found/error-report-3.json
+++ b/assets/validation-rules/missing-values-found/error-report-3.json
@@ -17,7 +17,7 @@
                     "sitesRequired": "mandatory"
                 }
             ],
-            "message": "Mandatory column geoLat in table sites has a missing value in row 1"
+            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value"
         }
     ],
     "errors": []

--- a/assets/validation-rules/missing-values-found/error-report-3.json
+++ b/assets/validation-rules/missing-values-found/error-report-3.json
@@ -17,7 +17,7 @@
                     "sitesRequired": "mandatory"
                 }
             ],
-            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value"
+            "message": "missing_values_found rule triggered in table sites, column geoLat, row 1: Missing value \"NA\""
         }
     ],
     "errors": []

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -118,7 +118,7 @@ def _fmt_msg_value(value: Any, relaxed=False) -> Any:
 
 
 def _gen_error_msg(ctx: ErrorCtx, template: Optional[str] = None,
-                   kind: Optional[ErrorKind] = None):
+                   error_kind: Optional[ErrorKind] = None):
     ":param template: overrides ctx.err_template"
     # requirements for error message:
     # - prefix with sortable order: table before column, etc.
@@ -126,9 +126,14 @@ def _gen_error_msg(ctx: ErrorCtx, template: Optional[str] = None,
     #   "<rule> in <table> in <column>", etc.
     # - quote values and constraints, since it's hard to distinguish them from
     #   the text otherwise.
-    verb = 'violated' if kind == ErrorKind.ERROR else 'triggered'
+    verb = 'violated' if error_kind == ErrorKind.ERROR else 'triggered'
+
     prefix = ('{rule_id} rule ' + verb + ' in '
-              'table {table_id}, column {column_id}, row {row_num}: ')
+              'table {table_id}, column {column_id}')
+    if ctx.data_kind == DataKind.python:
+        prefix += ', row {row_num}'
+    prefix += ': '
+
     if not template:
         template = ctx.err_template
     template = prefix + template

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -10,6 +10,7 @@ from input_data import DataKind
 from rules import RuleId, COERCION_RULE_ID
 from stdext import (
     get_len,
+    quote,
     type_name,
 )
 
@@ -98,29 +99,49 @@ def _fmt_dataset_values(rows: List[pt.Row]) -> List[pt.Row]:
     return list(map(_fmt_row, rows))
 
 
-def _fmt_rule_name(rule_id: str):
-    return rule_id.replace('_', ' ').capitalize()
-
-
 def _fmt_allowed_values(values: Set[str]) -> str:
     # XXX: The order of set-elements isn't deterministic, so we need to sort.
     return '/'.join(sorted(values))
 
 
-def _gen_error_msg(ctx: ErrorCtx, template: Optional[str] = None):
+def _fmt_msg_value(value: Any, relaxed=False) -> Any:
+    """Quote `value` as needed, in addition to the formatting done by
+    `_fmt_value`. This is meant to be used as part of another string/message.
+
+    :param relaxed: skips quotation when not needed.
+    """
+    fval = _fmt_value(value)
+    if relaxed and isinstance(fval, str):
+        if (fval != '') and (' ' not in fval):
+            return fval
+    return quote(str(fval))
+
+
+def _gen_error_msg(ctx: ErrorCtx, template: Optional[str] = None,
+                   kind: Optional[ErrorKind] = None):
     ":param template: overrides ctx.err_template"
+    # requirements for error message:
+    # - prefix with sortable order: table before column, etc.
+    # - prefix with natural order, as if it was a sentence:
+    #   "<rule> in <table> in <column>", etc.
+    # - quote values and constraints, since it's hard to distinguish them from
+    #   the text otherwise.
+    verb = 'violated' if kind == ErrorKind.ERROR else 'triggered'
+    prefix = ('{rule_id} rule ' + verb + ' in '
+              'table {table_id}, column {column_id}, row {row_num}: ')
     if not template:
         template = ctx.err_template
+    template = prefix + template
     return template.format(
         allowed_values=_fmt_allowed_values(ctx.allowed_values),
         column_id=ctx.column_id,
-        constraint=_fmt_value(ctx.constraint),
+        constraint=_fmt_msg_value(ctx.constraint, relaxed=True),
         row_num=_fmt_list(ctx.row_numbers),
-        rule_name=_fmt_rule_name(ctx.rule_id),
+        rule_id=ctx.rule_id,
         table_id=ctx.table_id,
-        value=_fmt_value(ctx.value),
+        value=_fmt_msg_value(ctx.value),
         value_len=get_len(ctx.value),
-        value_type=type_name(type(ctx.value)),
+        value_type=type_name(type(ctx.value))
     )
 
 
@@ -138,7 +159,7 @@ def gen_rule_error(ctx: ErrorCtx,
         'tableName': ctx.table_id,
         'columnName': ctx.column_id,
         'validationRuleFields': _fmt_dataset_values(rule_fields),
-        'message': _gen_error_msg(ctx, err_template),
+        'message': _gen_error_msg(ctx, err_template, kind),
     }
 
     # skip row info for spreadsheet-column errors
@@ -185,8 +206,7 @@ def _get_meta_rule_ids(column_meta) -> Set[str]:
 def _gen_coercion_msg(ctx: ErrorCtx, kind: ErrorKind):
     orig_type_name = type_name(type(ctx.value))
     coerced_type_alias = _generalize_cerb_type_name(ctx.cerb_type_name)
-    result = ('Value {value} in row {row_num} in column {column_id} '
-              'in table {table_id} ')
+    result = 'Value {value} '
     if kind == ErrorKind.WARNING:
         result += f'is a {orig_type_name} and was '
     else:

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -128,10 +128,15 @@ def _gen_error_msg(ctx: ErrorCtx, template: Optional[str] = None,
     #   the text otherwise.
     verb = 'violated' if error_kind == ErrorKind.ERROR else 'triggered'
 
+    # prefix gen
     prefix = ('{rule_id} rule ' + verb + ' in '
               'table {table_id}, column {column_id}')
     if ctx.data_kind == DataKind.python:
-        prefix += ', row {row_num}'
+        if len(ctx.row_numbers) == 1:
+            prefix += ', row '
+        else:
+            prefix += ', rows '
+        prefix += '{row_num}'
     prefix += ': '
 
     if not template:

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -41,7 +41,7 @@ class Rule:
     - column_id
     - constraint
     - row_num
-    - rule_name
+    - rule_id
     - table_id
     - value
     - value_len
@@ -91,8 +91,7 @@ def init_rule(rule_id, error, gen_cerb_rules, gen_schema,
 
 def duplicate_entries_found():
     rule_id = duplicate_entries_found.__name__
-    err = ('Duplicate entries found in rows {row_num} with primary key column '
-           '{column_id} and primary key value {value} in table {table_id}')
+    err = ('Duplicate entries found with primary key value {value}')
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {'unique': True}
@@ -107,9 +106,8 @@ def duplicate_entries_found():
 def greater_than_max_length():
     rule_id = greater_than_max_length.__name__
     odm_key = 'maxLength'
-    err = ('Value {value} in row {row_num} in column {column_id} in table '
-           '{table_id} has length {value_len} which is greater than the max '
-           'length of {constraint}')
+    err = ('Value {value} has length {value_len} which is greater than the '
+           'max length of {constraint}')
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {'maxlength': try_parse_int(val_ctx.value)}
@@ -123,8 +121,7 @@ def greater_than_max_length():
 def greater_than_max_value():
     rule_id = greater_than_max_value.__name__
     odm_key = 'maxValue'
-    err = ('Value {value} in row {row_num} in column {column_id} in table '
-           '{table_id} is greater than the allowable maximum value of '
+    err = ('Value {value} is greater than the allowable maximum value of '
            '{constraint}')
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
@@ -140,14 +137,7 @@ def greater_than_max_value():
 
 def missing_mandatory_column():
     rule_id = missing_mandatory_column.__name__
-    err = '{rule_name} {column_id} in table {table_id}'
-    err_with_row = err + ' in row number {row_num}'
-
-    def get_error_template(odm_value: Any, odm_type: str, data_kind: DataKind):
-        if data_kind == DataKind.python:
-            return err_with_row
-        else:
-            return err
+    err = 'Missing mandatory column {column_id}'
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {'required': True}
@@ -156,15 +146,14 @@ def missing_mandatory_column():
         return gen_conditional_schema(data, ver, rule_id, gen_cerb_rules,
                                       is_mandatory)
 
-    return init_rule(rule_id, get_error_template, gen_cerb_rules, gen_schema,
+    return init_rule(rule_id, err, gen_cerb_rules, gen_schema,
                      is_column=True)
 
 
 def missing_values_found():
     # TODO: rename to missing_mandatory_value?
     rule_id = missing_values_found.__name__
-    err = ('Mandatory column {column_id} in table {table_id} has a missing '
-           'value in row {row_num}')
+    err = 'Missing value'
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {
@@ -183,8 +172,7 @@ def missing_values_found():
 def less_than_min_length():
     rule_id = less_than_min_length.__name__
     odm_key = 'minLength'
-    err = ('Value {value} in row {row_num} in column {column_id} in table '
-           '{table_id} has length {value_len} which is less than the min '
+    err = ('Value {value} has length {value_len} which is less than the min '
            'length of {constraint}')
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
@@ -202,8 +190,7 @@ def less_than_min_length():
 def less_than_min_value():
     rule_id = less_than_min_value.__name__
     odm_key = 'minValue'
-    err = ('Value {value} in row {row_num} in column {column_id} in table '
-           '{table_id} is less than the allowable minimum value of '
+    err = ('Value {value} is less than the allowable minimum value of '
            '{constraint}')
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
@@ -220,8 +207,7 @@ def less_than_min_value():
 def invalid_category():
     rule_id = invalid_category.__name__
     cerb_rule_key = 'allowed'
-    err = ('{rule_name} {value} found in row {row_num} '
-           'for column {column_id} in table {table_id}')
+    err = 'Invalid category {value}'
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {cerb_rule_key: None}
@@ -256,15 +242,11 @@ def invalid_category():
 def invalid_type():
     rule_id = invalid_type.__name__
     odm_key = 'dataType'
-    err_default = ('Value {value} in row {row_num} in column {column_id} in '
-                   'table {table_id} has type {value_type} but should be of '
+    err_default = ('Value {value} has type {value_type} but should be of '
                    'type {constraint} or coercable into a {constraint}')
-    err_bool = ('Column {column_id} in row {row_num} in table {table_id} is a '
-                'boolean but has value {value}. '
+    err_bool = ('Column {column_id} is a boolean but has value {value}. '
                 'Allowed values are {allowed_values}.')
-    err_date = ('Column {column_id} in row {row_num} in table {table_id} is a '
-                'datetime with value {value} that has an unsupported datetime '
-                'format. '
+    err_date = ('Column {column_id} is a datetime but has value {value}. '
                 'Allowed values are ISO 8601 standard full dates, full dates '
                 'and times, or full dates and times with timezone.')
 

--- a/src/odm_validation/rules.py
+++ b/src/odm_validation/rules.py
@@ -153,7 +153,12 @@ def missing_mandatory_column():
 def missing_values_found():
     # TODO: rename to missing_mandatory_value?
     rule_id = missing_values_found.__name__
-    err = 'Missing value'
+
+    def get_error_template(odm_value: Any, odm_type: str, data_kind: DataKind):
+        if odm_value == '':
+            return 'Empty string found'
+        else:
+            return 'Missing value {value}'
 
     def gen_cerb_rules(val_ctx: OdmValueCtx):
         return {
@@ -165,7 +170,7 @@ def missing_values_found():
         return gen_conditional_schema(data, ver, rule_id, gen_cerb_rules,
                                       is_mandatory)
 
-    return init_rule(rule_id, err, gen_cerb_rules, gen_schema,
+    return init_rule(rule_id, get_error_template, gen_cerb_rules, gen_schema,
                      is_warning=True, match_all_keys=True)
 
 

--- a/src/odm_validation/stdext.py
+++ b/src/odm_validation/stdext.py
@@ -104,3 +104,7 @@ def type_name(type_class) -> str:
     if result == 'str':
         result = 'string'
     return result
+
+
+def quote(x: str) -> str:
+    return f'"{x}"'

--- a/src/odm_validation/stdext.py
+++ b/src/odm_validation/stdext.py
@@ -104,8 +104,3 @@ def type_name(type_class) -> str:
     if result == 'str':
         result = 'string'
     return result
-
-
-def inc(x):
-    """Increment x by 1, as seen in Pascal."""
-    return x + 1

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -82,8 +82,9 @@ expected_coercion_warnings = [
         'coercionRules': ['myrule1', 'myrule2'],
         'columnName': 'amount',
         'invalidValue': '123',
-        'message': 'Value 123 in row 1 in column amount in table mytable is '
-                   'a string and was coerced into a number',
+        'message': ('_coercion rule triggered '
+                    'in table mytable, column amount, row 1: '
+                    'Value \"123\" is a string and was coerced into a number'),
         'row': {'amount': '123', 'unknown': 'asd'},
         'rowNumber': 1,
         'tableName': 'mytable',
@@ -97,8 +98,9 @@ expected_coercion_warnings = [
         'coercionRules': [],
         'columnName': 'quantity',
         'invalidValue': '567',
-        'message': 'Value 567 in row 2 in column quantity in table mytable is '
-                   'a string and was coerced into a number',
+        'message': ('_coercion rule triggered '
+                    'in table mytable, column quantity, row 2: '
+                    'Value \"567\" is a string and was coerced into a number'),
         'row': {'quantity': '567'},
         'rowNumber': 2,
         'tableName': 'mytable',

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -63,7 +63,9 @@ class TestReports(common.OdmTestCase):
         expected_errors = [{
             'columnName': 'addID',
             'errorType': 'missing_mandatory_column',
-            'message': 'Missing mandatory column addID in table addresses',
+            'message': ('missing_mandatory_column rule violated in '
+                        'table addresses, column addID, row 2: '
+                        'Missing mandatory column addID'),
             'tableName': 'addresses',
             'validationRuleFields': []
         }]

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -58,13 +58,13 @@ class TestReports(common.OdmTestCase):
             ]
         }
 
-        # just one error even tho there are 2 rows missing the
+        # just one error even tho there are 2 rows missing the column
         report = validate_data(schema, data, data_kind=DataKind.spreadsheet)
         expected_errors = [{
             'columnName': 'addID',
             'errorType': 'missing_mandatory_column',
             'message': ('missing_mandatory_column rule violated in '
-                        'table addresses, column addID, row 2: '
+                        'table addresses, column addID: '
                         'Missing mandatory column addID'),
             'tableName': 'addresses',
             'validationRuleFields': []


### PR DESCRIPTION
fixes #135 

Code has been written to add consistent metadata as a prefix to the error report message, and the corresponding information has been removed from the error template of each rule. Error report assets have also been updated to reflect this.