### PR TITLE
fix report serialization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==6.0.1
 python-dateutil==2.8.2
 semver==3.0.0.dev3
 toml==0.10.2
+typing_extensions==4.8.0

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -2,6 +2,7 @@ import datetime
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
+from typing_extensions import TypedDict
 # from pprint import pprint
 
 import part_tables as pt
@@ -38,8 +39,7 @@ class ErrorCtx:
     verbosity: int = 2
 
 
-@dataclass(frozen=True)
-class TableInfo:
+class TableInfo(TypedDict):
     columns: int
     rows: int
 

--- a/src/odm_validation/summarization.py
+++ b/src/odm_validation/summarization.py
@@ -214,8 +214,8 @@ def _gen_overview(report: ValidationReport,
     table_overviews = {}
     for table_id, info in report.table_info.items():
         table_overviews[table_id] = {
-            'columns': info.columns,
-            'rows': info.rows,
+            'columns': info['columns'],
+            'rows': info['rows'],
         }
 
     overview = {

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,2 @@
-jsons==1.6.3
 typer==0.7.0
 xlsx2csv==0.7.8


### PR DESCRIPTION
The TableInfo class which appears in the validation report, had to be made into a TypedDict to support normal json serialization in tools using it (namely the web validation tool).