### PR TITLE
doc: fix broken link

### DIFF
--- a/docs/specs/generate-validation-schema-function.qmd
+++ b/docs/specs/generate-validation-schema-function.qmd
@@ -16,7 +16,7 @@ package.
 ## Context
 
 The PHES-ODM data structure is complex. Trying to manually create the
-validation schema for the [validate_data](./module-functions.md#validate_data)
+validation schema for the [validate_data](./module-functions.md)
 function can be an error prone and laborious process, especially if the user
 tries to encode all the validation rules. However, programmatic generation of a
 validation schema is possible due to the efforts of the PHES-ODM team in

--- a/docs/specs/generate-validation-schema-function.qmd
+++ b/docs/specs/generate-validation-schema-function.qmd
@@ -16,7 +16,7 @@ package.
 ## Context
 
 The PHES-ODM data structure is complex. Trying to manually create the
-validation schema for the [validate_data](./module-functions.md#validate_data)
+validation schema for the [validate_data](./module-functions.md#validate-data)
 function can be an error prone and laborious process, especially if the user
 tries to encode all the validation rules. However, programmatic generation of a
 validation schema is possible due to the efforts of the PHES-ODM team in

--- a/docs/specs/generate-validation-schema-function.qmd
+++ b/docs/specs/generate-validation-schema-function.qmd
@@ -16,7 +16,7 @@ package.
 ## Context
 
 The PHES-ODM data structure is complex. Trying to manually create the
-validation schema for the [validate_data](./module-functions.md)
+validation schema for the [validate_data](./module-functions.md#validate_data)
 function can be an error prone and laborious process, especially if the user
 tries to encode all the validation rules. However, programmatic generation of a
 validation schema is possible due to the efforts of the PHES-ODM team in

--- a/docs/specs/summarize-report-function.qmd
+++ b/docs/specs/summarize-report-function.qmd
@@ -38,7 +38,7 @@ class SummarizedReport:
 
 ### Fields
 
-The following fields are shared with `ValidationReport` (and documented [here](module-functions.md)):
+The following fields are shared with `ValidationReport` (and documented [here](module-functions.md#validate_data)):
 
 - data_version
 - schema_version

--- a/docs/specs/summarize-report-function.qmd
+++ b/docs/specs/summarize-report-function.qmd
@@ -38,7 +38,7 @@ class SummarizedReport:
 
 ### Fields
 
-The following fields are shared with `ValidationReport` (and documented [here](module-functions.md#validate_data)):
+The following fields are shared with `ValidationReport` (and documented [here](module-functions.md)):
 
 - data_version
 - schema_version

--- a/docs/specs/summarize-report-function.qmd
+++ b/docs/specs/summarize-report-function.qmd
@@ -38,7 +38,7 @@ class SummarizedReport:
 
 ### Fields
 
-The following fields are shared with `ValidationReport` (and documented [here](module-functions.md#validate_data)):
+The following fields are shared with `ValidationReport` (and documented [here](module-functions.md#validate-data)):
 
 - data_version
 - schema_version


### PR DESCRIPTION
anchors aren't working for some reason, but we can ignore it in this case since it's easy to find the section referred to

fixes #119 