### PR TITLE
only use plural rows/rowNumbers in error, simplify int-ranges

### DIFF
--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-1.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-1.json
@@ -2,15 +2,15 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "aDate",
                 "partType": "attribute",
                 "version1Location": "variables",
                 "version1Table": "",
                 "version1Variable": "analysisDate",
                 "version1Category": "NA"
-            },
-            "rowNumber": 2,
+            }],
+            "rowNumbers": [2],
             "message": "Skipping row 2 when generating a version 1 schema. Version 1 value not found for column version1Table"
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-10.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-10.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "comp3",
                 "version1Location": "categories",
                 "version1Table": "WWSample",
                 "version1Variable": "WWSample",
                 "version1Category": ""
-            },
-            "rowNumber": 3,
+            }],
+            "rowNumbers": [3],
             "message": "Skipping row 3 when generating a version 1 schema. Version 1 value not found for column version1Category"
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-2.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-2.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "measures",
                 "version1Location": "",
                 "version1Table": "WWMeasure",
                 "version1Variable": "NA",
                 "version1Category": "NA"
-            },
-            "rowNumber": 1,
+            }],
+            "rowNumbers": [1],
             "message": "Skipping row 1 when generating a version 1 schema. Invalid value for version 1 column version1Location. Allowed values are \"tables\", \"variables\", or \"categories\""
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-3.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-3.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "measures",
                 "version1Location": "tables",
                 "version1Table": "",
                 "version1Variable": "NA",
                 "version1Category": "NA"
-            },
-            "rowNumber": 1,
+            }],
+            "rowNumbers": [1],
             "message": "Skipping row 1 when generating a version 1 schema. Version 1 value not found for column version1Table"
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-4.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-4.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "aDate",
                 "version1Location": "",
                 "version1Table": "WWMeasure",
                 "version1Variable": "analysisDate",
                 "version1Category": "NA"
-            },
-            "rowNumber": 2,
+            }],
+            "rowNumbers": [2],
             "message": "Skipping row 2 when generating a version 1 schema. Invalid value for version 1 column version1Location. Allowed values are \"tables\", \"variables\", or \"categories\""
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-5.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-5.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "aDate",
                 "version1Location": "variables",
                 "version1Table": "",
                 "version1Variable": "analysisDate",
                 "version1Category": "NA"
-            },
-            "rowNumber": 2,
+            }],
+            "rowNumbers": [2],
             "message": "Skipping row 2 when generating a version 1 schema. Version 1 value not found for column version1Table"
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-6.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-6.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "aDate",
                 "version1Location": "variables",
                 "version1Table": "WWMeasure",
                 "version1Variable": "",
                 "version1Category": "NA"
-            },
-            "rowNumber": 2,
+            }],
+            "rowNumbers": [2],
             "message": "Skipping row 2 when generating a version 1 schema. Version 1 value not found for column version1Variable"
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-7.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-7.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "comp3",
                 "version1Location": "",
                 "version1Table": "WWSample",
                 "version1Variable": "collection",
                 "version1Category": "grbCp3"
-            },
-            "rowNumber": 3,
+            }],
+            "rowNumbers": [3],
             "message": "Skipping row 3 when generating a version 1 schema. Invalid value for version 1 column version1Location. Allowed values are \"tables\", \"variables\", or \"categories\""
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-8.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-8.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "comp3",
                 "version1Location": "categories",
                 "version1Table": "",
                 "version1Variable": "collection",
                 "version1Category": "grbCp3"
-            },
-            "rowNumber": 3,
+            }],
+            "rowNumbers": [3],
             "message": "Skipping row 3 when generating a version 1 schema. Version 1 value not found for column version1Table"
         }
     ]

--- a/assets/specs/generate-validation-schema/missing-version1-fields/warning-9.json
+++ b/assets/specs/generate-validation-schema/missing-version1-fields/warning-9.json
@@ -2,14 +2,14 @@
     "warnings": [
         {
             "warningType": "missing_version1_fields",
-            "row": {
+            "rows": [{
                 "partID": "comp3",
                 "version1Location": "categories",
                 "version1Table": "WWSample",
                 "version1Variable": "",
                 "version1Category": "grbCp3"
-            },
-            "rowNumber": 3,
+            }],
+            "rowNumbers": [3],
             "message": "Skipping row 3 when generating a version 1 schema. Version 1 value not found for column version1Variable"
         }
     ]

--- a/assets/validation-rules/empty/error-report-allowed.json
+++ b/assets/validation-rules/empty/error-report-allowed.json
@@ -4,8 +4,8 @@
             "columnName": "allowedField",
             "invalidValue": "",
             "message": "missing_values_found rule triggered in table sites, column allowedField, row(s) 1: Empty string found",
-            "row": {"allowedField": "", "siteID": "1"},
-            "rowNumber": 1,
+            "rows": [{"allowedField": "", "siteID": "1"}],
+            "rowNumbers": [1],
             "tableName": "sites",
             "validationRuleFields": [],
             "warningType": "missing_values_found"
@@ -14,8 +14,8 @@
             "columnName": "allowedField",
             "invalidValue": "",
             "message": "missing_values_found rule triggered in table sites, column allowedField, row(s) 2: Empty string found",
-            "row": {"allowedField": "", "siteID": "2"},
-            "rowNumber": 2,
+            "rows": [{"allowedField": "", "siteID": "2"}],
+            "rowNumbers": [2],
             "tableName": "sites",
             "validationRuleFields": [],
             "warningType": "missing_values_found"
@@ -24,8 +24,8 @@
             "columnName": "allowedField",
             "invalidValue": "   ",
             "message": "missing_values_found rule triggered in table sites, column allowedField, row(s) 3: Missing value \"   \"",
-            "row": {"allowedField": "   ", "siteID": "3"},
-            "rowNumber": 3,
+            "rows": [{"allowedField": "   ", "siteID": "3"}],
+            "rowNumbers": [3],
             "tableName": "sites",
             "validationRuleFields": [],
             "warningType": "missing_values_found"
@@ -34,8 +34,8 @@
             "columnName": "allowedField",
             "invalidValue": "NA",
             "message": "missing_values_found rule triggered in table sites, column allowedField, row(s) 4: Missing value \"NA\"",
-            "row": {"allowedField": "NA", "siteID": "4"},
-            "rowNumber": 4,
+            "rows": [{"allowedField": "NA", "siteID": "4"}],
+            "rowNumbers": [4],
             "tableName": "sites",
             "validationRuleFields": [],
             "warningType": "missing_values_found"
@@ -47,8 +47,8 @@
             "errorType": "invalid_category",
             "invalidValue": "   ",
             "message": "invalid_category rule violated in table sites, column allowedField, row(s) 3: Invalid category \"   \"",
-            "row": {"allowedField": "   ", "siteID": "3"},
-            "rowNumber": 3,
+            "rows": [{"allowedField": "   ", "siteID": "3"}],
+            "rowNumbers": [3],
             "tableName": "sites",
             "validationRuleFields": []
         },
@@ -57,8 +57,8 @@
             "errorType": "invalid_category",
             "invalidValue": "NA",
             "message": "invalid_category rule violated in table sites, column allowedField, row(s) 4: Invalid category \"NA\"",
-            "row": {"allowedField": "NA", "siteID": "4"},
-            "rowNumber": 4,
+            "rows": [{"allowedField": "NA", "siteID": "4"}],
+            "rowNumbers": [4],
             "tableName": "sites",
             "validationRuleFields": []
         }

--- a/assets/validation-rules/empty/error-report-minlength.json
+++ b/assets/validation-rules/empty/error-report-minlength.json
@@ -6,8 +6,8 @@
             "columnName": "minlengthField",
             "validationRuleFields": [],
             "message": "missing_values_found rule triggered in table sites, column minlengthField, row(s) 1: Empty string found",
-            "rowNumber": 1,
-            "row": {"siteID": "1", "minlengthField": ""},
+            "rowNumbers": [1],
+            "rows": [{"siteID": "1", "minlengthField": ""}],
             "invalidValue": ""
         },
         {
@@ -16,8 +16,8 @@
             "columnName": "minlengthField",
             "validationRuleFields": [],
             "message": "missing_values_found rule triggered in table sites, column minlengthField, row(s) 2: Empty string found",
-            "rowNumber": 2,
-            "row": {"siteID": "2", "minlengthField": ""}, "invalidValue": ""
+            "rowNumbers": [2],
+            "rows": [{"siteID": "2", "minlengthField": ""}], "invalidValue": ""
         },
         {
             "warningType": "missing_values_found",
@@ -25,8 +25,8 @@
             "columnName": "minlengthField",
             "validationRuleFields": [],
             "message": "missing_values_found rule triggered in table sites, column minlengthField, row(s) 3: Missing value \"   \"",
-            "rowNumber": 3,
-            "row": {"siteID": "3", "minlengthField": "   "},
+            "rowNumbers": [3],
+            "rows": [{"siteID": "3", "minlengthField": "   "}],
             "invalidValue": "   "
         },
         {
@@ -35,8 +35,8 @@
             "columnName": "minlengthField",
             "validationRuleFields": [],
             "message": "missing_values_found rule triggered in table sites, column minlengthField, row(s) 4: Missing value \"NA\"",
-            "rowNumber": 4,
-            "row": {"siteID": "4", "minlengthField": "NA"},
+            "rowNumbers": [4],
+            "rows": [{"siteID": "4", "minlengthField": "NA"}],
             "invalidValue": "NA"
         }
     ],
@@ -47,8 +47,8 @@
             "columnName": "minlengthField",
             "validationRuleFields": [],
             "message": "less_than_min_length rule violated in table sites, column minlengthField, row(s) 3: Value \"   \" (of length 3) is less than the min length of \"5\"",
-            "rowNumber": 3,
-            "row": {"siteID": "3", "minlengthField": "   "},
+            "rowNumbers": [3],
+            "rows": [{"siteID": "3", "minlengthField": "   "}],
             "invalidValue": "   "
         },
         {
@@ -57,8 +57,8 @@
             "columnName": "minlengthField",
             "validationRuleFields": [],
             "message": "less_than_min_length rule violated in table sites, column minlengthField, row(s) 4: Value \"NA\" (of length 2) is less than the min length of \"5\"",
-            "rowNumber": 4,
-            "row": {"siteID": "4", "minlengthField": "NA"},
+            "rowNumbers": [4],
+            "rows": [{"siteID": "4", "minlengthField": "NA"}],
             "invalidValue": "NA"
         },
         {
@@ -67,8 +67,8 @@
             "columnName": "minlengthField",
             "validationRuleFields": [],
             "message": "less_than_min_length rule violated in table sites, column minlengthField, row(s) 5: Value \"x\" (of length 1) is less than the min length of \"5\"",
-            "rowNumber" : 5,
-            "row": {"siteID": "5", "minlengthField": "x"},
+            "rowNumbers": [5],
+            "rows": [{"siteID": "5", "minlengthField": "x"}],
             "invalidValue": "x"
         }
     ]

--- a/assets/validation-rules/greater-than-max-length/error-report.json
+++ b/assets/validation-rules/greater-than-max-length/error-report.json
@@ -4,11 +4,11 @@
             "errorType": "greater_than_max_length",
             "tableName": "contacts",
             "columnName": "phone",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "contactID": "1",
                 "phone": "123-456-111"
-            },
+            }],
             "invalidValue": "123-456-111",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/greater-than-max-value/error-report-1.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-1.json
@@ -4,12 +4,12 @@
             "errorType": "greater_than_max_value",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": 91,
                 "geoLong": 90.2
-            },
+            }],
             "invalidValue": 91,
             "validationRuleFields": [
                 {
@@ -24,12 +24,12 @@
             "errorType": "greater_than_max_value",
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": 91,
                 "geoLong": 90.2
-            },
+            }],
             "invalidValue": 90.2,
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/greater-than-max-value/error-report-2.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-2.json
@@ -4,12 +4,12 @@
             "errorType": "greater_than_max_value",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": 91,
                 "geoLong": 90.2
-            },
+            }],
             "invalidValue": 91,
             "validationRuleFields": [
                 {
@@ -24,12 +24,12 @@
             "errorType": "greater_than_max_value",
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": 91,
                 "geoLong": 90.2
-            },
+            }],
             "invalidValue": 90.2,
             "validationRuleFields": [
                 {
@@ -47,12 +47,12 @@
 	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "91",
                 "geoLong": "90.2"
-            },
+            }],
             "invalidValue": "91",
             "validationRuleFields": [
                 {
@@ -68,12 +68,12 @@
 	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "91",
                 "geoLong": "90.2"
-            },
+            }],
             "invalidValue": "90.2",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/greater-than-max-value/error-report-3.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-3.json
@@ -5,12 +5,12 @@
             "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "a",
                 "geoLong": "b"
-            },
+            }],
             "invalidValue": "a",
             "validationRuleFields": [
                 {
@@ -26,12 +26,12 @@
             "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "a",
                 "geoLong": "b"
-            },
+            }],
             "invalidValue": "b",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/greater-than-max-value/error-report-4.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-4.json
@@ -4,11 +4,11 @@
             "errorType": "greater_than_max_value",
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": 1,
                 "lastEdited": "2024-12-30 00:00:00"
-            },
+            }],
             "invalidValue": "2024-12-30 00:00:00",
             "validationRuleFields": [
                 {
@@ -26,11 +26,11 @@
             "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "lastEdited": "2024-12-30",
                 "siteID": 1
-            },
+            }],
             "invalidValue": "2024-12-30",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/greater-than-max-value/error-report-pass-2.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-pass-2.json
@@ -6,12 +6,12 @@
 	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "89",
                 "geoLong": "90.1"
-            },
+            }],
             "invalidValue": "89",
             "validationRuleFields": [
                 {
@@ -27,12 +27,12 @@
 	    "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "89",
                 "geoLong": "90.1"
-            },
+            }],
             "invalidValue": "90.1",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/greater-than-max-value/error-report-pass-4.json
+++ b/assets/validation-rules/greater-than-max-value/error-report-pass-4.json
@@ -6,11 +6,11 @@
             "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": 1,
                 "lastEdited": "2023-01-30"
-            },
+            }],
             "invalidValue": "2023-01-30",
             "validationRuleFields": [
                 {
@@ -26,11 +26,11 @@
             "coercionRules": ["greater_than_max_value"],
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 2,
-            "row": {
+            "rowNumbers": [2],
+            "rows": [{
                 "siteID": 2,
                 "lastEdited": "2023-01-30T00:00:00"
-            },
+            }],
             "invalidValue": "2023-01-30T00:00:00",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/invalid-category/error-report.json
+++ b/assets/validation-rules/invalid-category/error-report.json
@@ -4,10 +4,10 @@
             "errorType": "invalid_category",
             "tableName": "samples",
             "columnName": "coll",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "coll": "flow"
-            },
+            }],
             "invalidValue": "flow",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/invalid-email/error-report-1.json
+++ b/assets/validation-rules/invalid-email/error-report-1.json
@@ -4,11 +4,11 @@
             "errorType": "invalid_email",
             "tableName": "contacts",
             "columnName": "email",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "contactID": "1",
                 "email": "john.doe"
-            },
+            }],
             "invalidValue": "john.doe",
             "validationRuleFields": [],
             "message": "Invalid email john.doe found in row 1 for column email in table contacts"

--- a/assets/validation-rules/invalid-type/bool-error-report-1.json
+++ b/assets/validation-rules/invalid-type/bool-error-report-1.json
@@ -4,11 +4,11 @@
             "errorType": "invalid_type",
             "tableName": "measures",
             "columnName": "reportable",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "measureID": "1",
                 "reportable": "Yes"
-            },
+            }],
             "invalidValue": "Yes",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/invalid-type/bool-error-report-2.json
+++ b/assets/validation-rules/invalid-type/bool-error-report-2.json
@@ -4,11 +4,11 @@
             "errorType": "invalid_type",
             "tableName": "measures",
             "columnName": "reportable",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "measureID": "1",
                 "reportable": "true"
-            },
+            }],
             "invalidValue": "true",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/invalid-type/datetime-error-report-1.json
+++ b/assets/validation-rules/invalid-type/datetime-error-report-1.json
@@ -4,11 +4,11 @@
             "errorType": "invalid_type",
             "tableName": "measures",
             "columnName": "reportDate",
-            "row": {
+            "rows": [{
                 "measureID": "1",
                 "reportDate": "a"
-            },
-            "rowNumber": 1,
+            }],
+            "rowNumbers": [1],
             "invalidValue": "a",
             "validationRuleFields": [
                 {
@@ -23,11 +23,11 @@
             "errorType": "invalid_type",
             "tableName": "measures",
             "columnName": "reportDate",
-            "row": {
+            "rows": [{
                 "measureID": "2",
                 "reportDate": "2022"
-            },
-            "rowNumber": 2,
+            }],
+            "rowNumbers": [2],
             "invalidValue": "2022",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/invalid-type/float-error-report-1.json
+++ b/assets/validation-rules/invalid-type/float-error-report-1.json
@@ -4,11 +4,11 @@
             "errorType": "invalid_type",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "a"
-            },
+            }],
             "invalidValue": "a",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/invalid-type/integer-error-report-1.json
+++ b/assets/validation-rules/invalid-type/integer-error-report-1.json
@@ -4,11 +4,11 @@
             "errorType": "invalid_type",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": 1,
                 "geoLat": 1.23
-            },
+            }],
             "invalidValue": 1.23,
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/invalid-type/integer-error-report-2.json
+++ b/assets/validation-rules/invalid-type/integer-error-report-2.json
@@ -4,11 +4,11 @@
             "errorType": "invalid_type",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "a"
-            },
+            }],
             "invalidValue": "a",
             "validationRuleFields": [
                 {
@@ -23,11 +23,11 @@
             "errorType": "invalid_type",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 2,
-            "row": {
+            "rowNumbers": [2],
+            "rows": [{
                 "siteID": "2",
                 "geoLat": "1.01"
-            },
+            }],
             "invalidValue": "1.01",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/less-than-min-length/error-report.json
+++ b/assets/validation-rules/less-than-min-length/error-report.json
@@ -4,11 +4,11 @@
             "errorType": "less_than_min_length",
             "tableName": "contacts",
             "columnName": "phone",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "contactID": "1",
                 "phone": "123-456-1"
-            },
+            }],
             "invalidValue": "123-456-1",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/less-than-min-value/error-report-1.json
+++ b/assets/validation-rules/less-than-min-value/error-report-1.json
@@ -4,12 +4,12 @@
             "errorType": "less_than_min_value",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": 1,
                 "geoLat": -91,
                 "geoLong": -90.2
-            },
+            }],
             "invalidValue": -91,
             "validationRuleFields": [
                 {
@@ -24,12 +24,12 @@
             "errorType": "less_than_min_value",
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": 1,
                 "geoLat": -91,
                 "geoLong": -90.2
-            },
+            }],
 	    "invalidValue": -90.2,
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/less-than-min-value/error-report-2.json
+++ b/assets/validation-rules/less-than-min-value/error-report-2.json
@@ -4,12 +4,12 @@
             "errorType": "less_than_min_value",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": -91,
                 "geoLong": -90.2
-            },
+            }],
             "invalidValue": -91,
             "validationRuleFields": [
                 {
@@ -24,12 +24,12 @@
             "errorType": "less_than_min_value",
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": -91,
                 "geoLong": -90.2
-            },
+            }],
             "invalidValue": -90.2,
             "validationRuleFields": [
                 {
@@ -47,12 +47,12 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "-91",
                 "geoLong": "-90.2"
-            },
+            }],
             "invalidValue": "-91",
             "validationRuleFields": [
                 {
@@ -68,12 +68,12 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "-91",
                 "geoLong": "-90.2"
-            },
+            }],
             "invalidValue": "-90.2",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/less-than-min-value/error-report-3.json
+++ b/assets/validation-rules/less-than-min-value/error-report-3.json
@@ -5,12 +5,12 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "a",
                 "geoLong": "b"
-            },
+            }],
             "invalidValue": "a",
             "validationRuleFields": [
                 {
@@ -26,12 +26,12 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "a",
                 "geoLong": "b"
-            },
+            }],
             "invalidValue": "b",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/less-than-min-value/error-report-4.json
+++ b/assets/validation-rules/less-than-min-value/error-report-4.json
@@ -4,11 +4,11 @@
             "errorType": "less_than_min_value",
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": 1,
                 "lastEdited": "2022-12-30 00:00:00"
-            },
+            }],
             "invalidValue": "2022-12-30 00:00:00",
             "validationRuleFields": [
                 {
@@ -26,11 +26,11 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "lastEdited": "2022-12-30",
                 "siteID": 1
-            },
+            }],
             "invalidValue": "2022-12-30",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/less-than-min-value/error-report-pass-2.json
+++ b/assets/validation-rules/less-than-min-value/error-report-pass-2.json
@@ -6,12 +6,12 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "-89",
                 "geoLong": "-90"
-            },
+            }],
             "invalidValue": "-89",
             "validationRuleFields": [
                 {
@@ -27,12 +27,12 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "geoLong",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "-89",
                 "geoLong": "-90"
-            },
+            }],
             "invalidValue": "-90",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/less-than-min-value/error-report-pass-4.json
+++ b/assets/validation-rules/less-than-min-value/error-report-pass-4.json
@@ -6,11 +6,11 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": 1,
                 "lastEdited": "2023-01-30"
-            },
+            }],
             "invalidValue": "2023-01-30",
             "validationRuleFields": [
                 {
@@ -26,11 +26,11 @@
             "coercionRules": ["less_than_min_value"],
             "tableName": "sites",
             "columnName": "lastEdited",
-            "rowNumber": 2,
-            "row": {
+            "rowNumbers": [2],
+            "rows": [{
                 "siteID": 2,
                 "lastEdited": "2023-01-30T00:00:00"
-            },
+            }],
             "invalidValue": "2023-01-30T00:00:00",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/missing-mandatory-column/error-report.json
+++ b/assets/validation-rules/missing-mandatory-column/error-report.json
@@ -4,10 +4,10 @@
             "errorType": "missing_mandatory_column",
             "tableName": "addresses",
             "columnName": "addID",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "addL2": "123 Doe Street"
-            },
+            }],
             "validationRuleFields": [
                 {
                     "addresses": "pK",

--- a/assets/validation-rules/missing-values-found/error-report-1.json
+++ b/assets/validation-rules/missing-values-found/error-report-1.json
@@ -4,11 +4,11 @@
             "warningType": "missing_values_found",
             "tableName": "sites",
             "columnName": "geoLat",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": ""
-            },
+            }],
             "invalidValue": "",
             "validationRuleFields": [
                 {

--- a/assets/validation-rules/missing-values-found/error-report-2.json
+++ b/assets/validation-rules/missing-values-found/error-report-2.json
@@ -5,11 +5,11 @@
             "tableName": "sites",
             "columnName": "geoLat",
             "invalidValue": "  ",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "  "
-            },
+            }],
             "validationRuleFields": [
                 {
                     "partID": "geoLat",

--- a/assets/validation-rules/missing-values-found/error-report-3.json
+++ b/assets/validation-rules/missing-values-found/error-report-3.json
@@ -5,11 +5,11 @@
             "tableName": "sites",
             "columnName": "geoLat",
             "invalidValue": "NA",
-            "rowNumber": 1,
-            "row": {
+            "rowNumbers": [1],
+            "rows": [{
                 "siteID": "1",
                 "geoLat": "NA"
-            },
+            }],
             "validationRuleFields": [
                 {
                     "partID": "geoLat",

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -1,4 +1,5 @@
 import datetime
+from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, TypedDict, Union, cast
@@ -9,13 +10,11 @@ from odm_validation.part_tables import SomeValue
 from odm_validation.input_data import DataKind
 from odm_validation.rules import get_anyof_constraint, RuleId
 from odm_validation.stdext import (
+    IntRange,
     get_len,
     quote,
     type_name,
 )
-
-
-IntRange = tuple[int, int]
 
 
 class ErrorKind(Enum):
@@ -72,6 +71,32 @@ class ValidationReport:
         return len(self.errors) == 0
 
 
+def _fix_error_ranges(e: dict) -> None:
+    '''fixes error ranges in-place'''
+    arrRanges = e.get('rowNumbers')
+    if not arrRanges:
+        return
+    tupRanges: list[IntRange] = []
+    for r in arrRanges:
+        if isinstance(r, int):
+            tupRanges.append(r)
+        else:
+            assert isinstance(r, list)
+            tupRanges.append(tuple(r))
+    e['rowNumbers'] = tupRanges
+
+
+def fix_json_report(report: dict) -> None:
+    '''fixes ranges (of type IntRange) loaded from json, which are encoded as
+    arrays, and therefore would be interpreted as lists without this (in-place)
+    transform.
+    '''
+    for e in report['errors']:
+        _fix_error_ranges(e)
+    for e in report['warnings']:
+        _fix_error_ranges(e)
+
+
 def join_reports(a: Optional[ValidationReport], b: ValidationReport
                  ) -> ValidationReport:
     """Joins two reports together into a new report."""
@@ -92,20 +117,17 @@ def join_reports(a: Optional[ValidationReport], b: ValidationReport
 
 def _range_is_one(r: IntRange) -> bool:
     '''returns true if the range has a single element'''
-    return r[0] == r[1]
-
-
-def _ranges_are_one(ranges: list[IntRange]) -> bool:
-    '''returns true if there is just a single element in the list of ranges'''
-    return len(ranges) == 1 and _range_is_one(ranges[0])
+    return isinstance(r, int) or r[0] == r[1]
 
 
 def _fmt_range_list(ranges: list[IntRange]) -> str:
 
     def fmt_range(r: IntRange) -> str:
         if _range_is_one(r):
-            return str(r[0])
+            x = r if isinstance(r, int) else r[0]
+            return str(x)
         else:
+            assert isinstance(r, tuple)
             return f'{r[0]}..{r[1]}'
 
     return ','.join(map(fmt_range, ranges))
@@ -157,7 +179,7 @@ def _fmt_msg_value(value: Optional[SomeValue], relaxed: bool = False) -> str:
 
 
 def _gen_error_msg(ctx: ErrorCtx,
-                   row_number_ranges: list[tuple[int, int]],
+                   row_number_ranges: list[IntRange],
                    template: Optional[str] = None,
                    error_kind: Optional[ErrorKind] = None) -> str:
     ":param template: overrides ctx.err_template"
@@ -270,18 +292,10 @@ def gen_rule_error(ctx: ErrorCtx,
         return error
 
     # row numbers
-    if len(row_number_ranges) > 0:
-        if _ranges_are_one(row_number_ranges):
-            error['rowNumber'] = row_number_ranges[0][0]
-        else:
-            error['rowNumbers'] = row_number_ranges
+    error['rowNumbers'] = row_number_ranges
 
     # rows
-    rows = _fmt_dataset_values(ctx.rows)
-    if len(ctx.rows) > 1:
-        error['rows'] = rows
-    else:
-        error['row'] = rows[0]
+    error['rows'] = _fmt_dataset_values(ctx.rows)
 
     # value
     if ctx.value is not None:

--- a/src/odm_validation/reports.py
+++ b/src/odm_validation/reports.py
@@ -1,5 +1,4 @@
 import datetime
-from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, TypedDict, Union, cast

--- a/src/odm_validation/rule_errors.py
+++ b/src/odm_validation/rule_errors.py
@@ -232,8 +232,7 @@ def _get_table_name(x: dict) -> str:
 
 
 def _get_first_row_num(x: dict) -> int:
-    return (x.get('rowNumber', 0) or
-            next(stdext.expand_ranges(x.get('rowNumbers', [])), 0))
+    return next(stdext.expand_ranges(x.get('rowNumbers', [])), 0)
 
 
 def _get_column_name(x: dict) -> str:

--- a/src/odm_validation/stdext.py
+++ b/src/odm_validation/stdext.py
@@ -1,4 +1,3 @@
-import sys
 import dateutil.parser as dateutil_parser
 import json
 import operator

--- a/src/odm_validation/stdext.py
+++ b/src/odm_validation/stdext.py
@@ -1,9 +1,13 @@
+import sys
 import dateutil.parser as dateutil_parser
 import json
 import operator
 from datetime import datetime
 from functools import reduce
 from typing import Generator, Iterator, Optional, Union
+
+
+IntRange = Union[int, tuple[int, int]]
 
 
 def get_len(x: Union[int, float, str, list, dict, datetime]) -> int:
@@ -181,7 +185,14 @@ def keep(x: Union[dict, list], target: str) -> None:
             i += 1
 
 
-def gen_ranges(xs: list[int]) -> list[tuple[int, int]]:
+def _append_range(ranges: list[IntRange], low: int, high: int) -> None:
+    if low == high:
+        ranges.append(low)
+    else:
+        ranges.append((low, high))
+
+
+def gen_ranges(xs: list[int]) -> list[IntRange]:
     '''Converts a list of numbers to a list of pairs, where each pair is the
     first and last number in a range. A range can either be of a single
     number, like 1..1, or multiple, like 2..15.
@@ -190,7 +201,7 @@ def gen_ranges(xs: list[int]) -> list[tuple[int, int]]:
     '''
     if len(xs) == 0:
         return []
-    result: list[tuple[int, int]] = []
+    result: list[IntRange] = []
     low = xs[0]
     high = low
     for i in range(1, len(xs)):
@@ -198,18 +209,21 @@ def gen_ranges(xs: list[int]) -> list[tuple[int, int]]:
         if x < low:
             raise ValueError('numbers are not in ascending order')
         if x > high + 1:
-            result.append((low, high))
+            _append_range(result, low, high)
             low = x
         high = x
-    result.append((low, high))
+    _append_range(result, low, high)
     return result
 
 
-def expand_ranges(ranges: list[tuple[int, int]]) -> Generator[int, None, None]:
-    '''expands a list of int-ranges'''
-    # print('expand', ranges)
+def expand_ranges(ranges: list[IntRange]
+                  ) -> Generator[int, None, None]:
+    '''Expands a list of int-ranges. Ranges from and to the same int can be
+    written as a single int instead of a tuple.'''
     for r in ranges:
-        # print('range', r)
-        for i in range(r[0], r[1]+1):
-            # print('yield', i)
-            yield i
+        if isinstance(r, int):
+            yield r
+        else:
+            assert isinstance(r, tuple), str(r)
+            for i in range(r[0], r[1]+1):
+                yield i

--- a/src/odm_validation/summarization.py
+++ b/src/odm_validation/summarization.py
@@ -101,11 +101,7 @@ def _get_error_table_rule(e: dict) -> tuple[TableId, RuleId]:
 
 
 def _get_error_row_ids(e: dict) -> list[int]:
-    row_id0 = e.get('rowNumber')
-    if row_id0 is not None:
-        return [row_id0]
-    else:
-        return list(stdext.expand_ranges(e['rowNumbers']))
+    return list(stdext.expand_ranges(e.get('rowNumbers', [])))
 
 
 def _count_errors(keys: set[SummaryKey], errors: list) -> Counts:
@@ -127,14 +123,10 @@ def _count_errors(keys: set[SummaryKey], errors: list) -> Counts:
     total_counts: ErrorCounts = defaultdict(Count)
     key_counts: dict[SummaryKey, TableCounts] = defaultdict(dict)
     for e in errors:
+        # XXX: when no rows, it's a column error, and count=1
         table_id, rule_id = _get_error_table_rule(e)
-        is_row_err = 'rowNumber' in e or 'rowNumbers' in e
-        if is_row_err:
-            row_ids = _get_error_row_ids(e)
-            count = len(row_ids)
-        else:
-            row_ids = []
-            count = 1
+        row_ids = _get_error_row_ids(e)
+        count = max(1, len(row_ids))
         total_counts[rule_id] += count
         for key in keys:
             if key == SummaryKey.ROW:

--- a/src/odm_validation/tools/summarize.py
+++ b/src/odm_validation/tools/summarize.py
@@ -10,7 +10,7 @@ from typing import IO, Optional
 
 import typer
 
-from odm_validation.reports import ErrorKind, ValidationReport
+from odm_validation.reports import ErrorKind, ValidationReport, fix_json_report
 from odm_validation.summarization import (
     SummarizedReport,
     SummaryEntry,
@@ -81,6 +81,8 @@ def read_report_from_file(file: IO) -> Optional[ValidationReport]:
     report_obj: Optional[dict] = None
     if fmt == ReportFormat.JSON:
         report_obj = json.loads(raw_data)
+        if report_obj:
+            fix_json_report(report_obj)
     elif fmt == ReportFormat.YAML:
         logging.warn('you should use json-reports instead of yaml when ' +
                      'summarizing, since yaml parsing is extremely slow')

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,7 +5,7 @@ package modules.
 
 import logging
 import unittest
-from copy import copy, deepcopy
+from copy import deepcopy
 from glob import glob
 from os.path import join, splitext
 from pathlib import Path
@@ -13,6 +13,7 @@ from typing import Union
 
 import odm_validation.odm as odm
 import odm_validation.utils as utils
+from odm_validation.reports import fix_json_report
 
 
 # TODO: make this global lower-case, since it's not constant
@@ -27,18 +28,11 @@ ROOT_DIR = Path(__file__).parent.parent
 ASSET_DIR = join(ROOT_DIR, 'assets')
 
 
-def fixErrorRanges(e: dict) -> dict:
-    '''fixes ranges/tuples loaded from json, which are encoded as arrays, and
-    therefore would be interpreted as lists without this transform.'''
-    e = copy(e)
-    arrRanges = e.get('rowNumbers')
-    if not arrRanges:
-        return e
-    tupRanges = []
-    for r in arrRanges:
-        tupRanges.append(tuple(r))
-    e['rowNumbers'] = tupRanges
-    return e
+def import_report(path) -> dict:
+    '''imports an error report from `path'''
+    report = utils.import_json_file(path)
+    fix_json_report(report)
+    return report
 
 
 class OdmTestCase(unittest.TestCase):
@@ -53,8 +47,7 @@ class OdmTestCase(unittest.TestCase):
         self.assertTrue([single_entry], cm.output)
 
     def assertReportEqual(self, expected, report):
-        expErrors = list(map(fixErrorRanges, expected['errors']))
-        self.assertEqual(expErrors, report.errors)
+        self.assertEqual(expected['errors'], report.errors)
         self.assertEqual(expected['warnings'], report.warnings)
 
 

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -85,8 +85,8 @@ expected_coercion_warnings = [
         'message': ('_coercion rule triggered '
                     'in table mytable, column amount, row(s) 1: '
                     'Value \"123\" is a string and was coerced into a number'),
-        'row': {'amount': '123', 'unknown': 'asd'},
-        'rowNumber': 1,
+        'rows': [{'amount': '123', 'unknown': 'asd'}],
+        'rowNumbers': [1],
         'tableName': 'mytable',
         'validationRuleFields': [
             {'a': 'b'},
@@ -101,8 +101,8 @@ expected_coercion_warnings = [
         'message': ('_coercion rule triggered '
                     'in table mytable, column quantity, row(s) 2: '
                     'Value \"567\" is a string and was coerced into a number'),
-        'row': {'quantity': '567'},
-        'rowNumber': 2,
+        'rows': [{'quantity': '567'}],
+        'rowNumbers': [2],
         'tableName': 'mytable',
         'validationRuleFields': [],
         'warningType': '_coercion'

--- a/tests/test_duplicate_entries_found.py
+++ b/tests/test_duplicate_entries_found.py
@@ -5,17 +5,14 @@ from parameterized import parameterized
 import odm_validation.odm as odm
 from odm_validation.rules import RuleId
 from odm_validation.schemas import import_schema
-from odm_validation.utils import (
-    import_dataset,
-    import_json_file,
-)
+from odm_validation.utils import import_dataset
 from odm_validation.validation import (
     generate_validation_schema,
     _validate_data_ext,
 )
 
 import common
-from common import asset, gen_v2_testschemas, param_range
+from common import asset, gen_v2_testschemas, import_report, param_range
 
 
 class Assets():
@@ -39,8 +36,8 @@ class Assets():
 
         # error reports
         self.error_report = {
-            1: import_json_file(asset('error-report-1.json')),
-            2: import_json_file(asset('error-report-2.json'))
+            1: import_report(asset('error-report-1.json')),
+            2: import_report(asset('error-report-2.json'))
         }
 
 

--- a/tests/test_empty.py
+++ b/tests/test_empty.py
@@ -3,11 +3,11 @@ import unittest
 from parameterized import parameterized
 
 from odm_validation.schemas import import_schema
-from odm_validation.utils import import_dataset, import_json_file
+from odm_validation.utils import import_dataset
 from odm_validation.validation import _validate_data_ext
 
 import common
-from common import asset
+from common import asset, import_report
 
 
 class TestEmpty(common.OdmTestCase):
@@ -24,7 +24,7 @@ class TestEmpty(common.OdmTestCase):
         schema = import_schema(asset(f'schema-v2-{rulename}.yml'))
         data = {'sites': import_dataset(asset(f'dataset-{rulename}.csv'))}
         report = _validate_data_ext(schema, data)
-        expected = import_json_file(asset(f'error-report-{rulename}.json'))
+        expected = import_report(asset(f'error-report-{rulename}.json'))
         self.assertReportEqual(expected, report)
 
 

--- a/tests/test_invalid_category.py
+++ b/tests/test_invalid_category.py
@@ -5,10 +5,7 @@ from parameterized import parameterized
 import odm_validation.odm as odm
 from odm_validation.rules import RuleId
 from odm_validation.schemas import import_schema
-from odm_validation.utils import (
-    import_dataset,
-    import_json_file,
-)
+from odm_validation.utils import import_dataset
 from odm_validation.validation import (
     _generate_validation_schema_ext,
     validate_data,
@@ -16,7 +13,7 @@ from odm_validation.validation import (
 # from odm_validation.versions import Version
 
 import common
-from common import asset
+from common import asset, import_report
 
 
 common.ASSET_SUBDIR = 'validation-rules/invalid-category'
@@ -27,7 +24,7 @@ sets = import_dataset(asset('sets.csv'))
 schema_v1 = import_schema(asset('schema-v1.yml'))
 schema_v2 = import_schema(asset('schema-v2.yml'))
 v2_schemas = common.gen_v2_testschemas(schema_v2)
-error_report = import_json_file(asset('error-report.json'))
+error_report = import_report(asset('error-report.json'))
 
 invalid_category_pass_1_v2 = {
     'samples': import_dataset(asset('valid-dataset-1.csv')),

--- a/tests/test_invalid_type.py
+++ b/tests/test_invalid_type.py
@@ -5,10 +5,7 @@ from parameterized import parameterized, parameterized_class
 import odm_validation.odm as odm
 from odm_validation.rules import RuleId
 from odm_validation.schemas import import_schema
-from odm_validation.utils import (
-    import_dataset,
-    import_json_file,
-)
+from odm_validation.utils import import_dataset
 from odm_validation.validation import (
     _generate_validation_schema_ext,
     _validate_data_ext,
@@ -21,6 +18,7 @@ from common import (
     gen_testschema,
     gen_v2_testschemas,
     import_dataset2,
+    import_report,
     param_range,
 )
 
@@ -57,11 +55,11 @@ class Assets():
 
         # error reports
         self.error_report = [
-            import_json_file(asset(f'{kind}-error-report-1.json')),
+            import_report(asset(f'{kind}-error-report-1.json')),
         ]
         if kind in {'bool', 'integer'}:
             self.error_report.append(
-                import_json_file(asset(f'{kind}-error-report-2.json')))
+                import_report(asset(f'{kind}-error-report-2.json')))
 
 
 @parameterized_class([

--- a/tests/test_min_max_length.py
+++ b/tests/test_min_max_length.py
@@ -5,17 +5,14 @@ from parameterized import parameterized, parameterized_class
 import odm_validation.odm as odm
 from odm_validation.rules import RuleId
 from odm_validation.schemas import import_schema
-from odm_validation.utils import (
-    import_dataset,
-    import_json_file,
-)
+from odm_validation.utils import import_dataset
 from odm_validation.validation import (
     _generate_validation_schema_ext,
     validate_data,
 )
 
 import common
-from common import asset, gen_v2_testschemas
+from common import asset, gen_v2_testschemas, import_report
 
 
 class Assets():
@@ -36,7 +33,7 @@ class Assets():
             'contacts': import_dataset(asset('invalid-dataset.csv'))
         }
 
-        self.error_report = import_json_file(asset('error-report.json'))
+        self.error_report = import_report(asset('error-report.json'))
 
 
 @parameterized_class([

--- a/tests/test_min_max_value.py
+++ b/tests/test_min_max_value.py
@@ -6,17 +6,20 @@ import odm_validation.odm as odm
 from odm_validation.rules import RuleId
 from odm_validation.schemas import import_schema
 from odm_validation.stdext import deep_update
-from odm_validation.utils import (
-    import_dataset,
-    import_json_file,
-)
+from odm_validation.utils import import_dataset
 from odm_validation.validation import (
     _generate_validation_schema_ext,
     _validate_data_ext,
 )
 
 import common
-from common import asset, gen_v2_testschemas, import_dataset2, param_range
+from common import (
+    asset,
+    gen_v2_testschemas,
+    import_dataset2,
+    import_report,
+    param_range,
+)
 
 
 class Assets():
@@ -44,9 +47,9 @@ class Assets():
         empty_report = {'errors': [], 'warnings': []}
         self.error_report_pass = [
             empty_report,
-            import_json_file(asset('error-report-pass-2.json')),
+            import_report(asset('error-report-pass-2.json')),
             empty_report,
-            import_json_file(asset('error-report-pass-4.json')),
+            import_report(asset('error-report-pass-4.json')),
         ]
 
         self.data_fail = []
@@ -55,7 +58,7 @@ class Assets():
             self.data_fail.append(
                 {'sites': import_dataset2(asset(f'invalid-dataset-{i}.*'))})
             self.error_report_fail.append(
-                import_json_file(asset(f'error-report-{i}.json')))
+                import_report(asset(f'error-report-{i}.json')))
 
 
 @parameterized_class([

--- a/tests/test_missing_mandatory_column.py
+++ b/tests/test_missing_mandatory_column.py
@@ -5,14 +5,14 @@ from parameterized import parameterized
 import odm_validation.odm as odm
 from odm_validation.rules import RuleId
 from odm_validation.schemas import import_schema
-from odm_validation.utils import import_dataset, import_json_file
+from odm_validation.utils import import_dataset
 from odm_validation.validation import (
     _generate_validation_schema_ext,
     validate_data,
 )
 
 import common
-from common import asset, gen_v2_testschemas
+from common import asset, gen_v2_testschemas, import_report
 
 
 common.ASSET_SUBDIR = 'validation-rules/missing-mandatory-column'
@@ -21,7 +21,7 @@ parts_v2 = import_dataset(asset('parts.csv'))
 schema_v1 = import_schema(asset('schema-v1.yml'))
 v2_schema = import_schema(asset('schema-v2.yml'))
 v2_schemas = gen_v2_testschemas(v2_schema)
-error_report = import_json_file(asset('error-report.json'))
+error_report = import_report(asset('error-report.json'))
 
 missing_mandatory_column_pass_v2 = {
     'addresses': import_dataset(asset('valid-dataset.csv')),

--- a/tests/test_missing_values_found.py
+++ b/tests/test_missing_values_found.py
@@ -5,14 +5,14 @@ from parameterized import parameterized
 import odm_validation.odm as odm
 from odm_validation.rules import RuleId
 from odm_validation.schemas import import_schema
-from odm_validation.utils import import_dataset, import_json_file
+from odm_validation.utils import import_dataset
 from odm_validation.validation import (
     _generate_validation_schema_ext,
     _validate_data_ext,
 )
 
 import common
-from common import asset, gen_v2_testschemas, param_range
+from common import asset, gen_v2_testschemas, import_report, param_range
 
 
 class Assets():
@@ -34,7 +34,7 @@ class Assets():
         for i in range(1, 4):
             self.data_fail[i] = \
                 {table: import_dataset(asset(f'invalid-dataset-{i}.csv'))}
-            self.reports[i] = import_json_file(asset(f'error-report-{i}.json'))
+            self.reports[i] = import_report(asset(f'error-report-{i}.json'))
 
 
 class TestMissingValuesFound(common.OdmTestCase):

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -43,8 +43,8 @@ class TestReports(common.OdmTestCase):
         data = {'addresses': [{'addID': 0}, {'addID': 1}, {'addID': 2}]}
         py_report = validate_data(schema, data, data_kind=DataKind.python)
         ss_report = validate_data(schema, data, data_kind=DataKind.spreadsheet)
-        self.assertEqual(py_report.errors[0]['rowNumber'], 3)
-        self.assertEqual(ss_report.errors[0]['rowNumber'], 4)
+        self.assertEqual(py_report.errors[0]['rowNumbers'], [3])
+        self.assertEqual(ss_report.errors[0]['rowNumbers'], [4])
 
     def test_column_rules_reported_once_for_spreadsheet(self):
         schema = deepcopy(base_schema)
@@ -118,7 +118,7 @@ class TestReports(common.OdmTestCase):
         data = {'addresses': [{'asd': '123'}]}
         report = validate_data(schema, data, data_kind=DataKind.spreadsheet)
         msg = report.errors[0]['message']
-        self.assertFalse('row' in msg)
+        self.assertFalse('rows' in msg)
         self.assertTrue('column addID:' in msg)
 
 

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -27,19 +27,19 @@ errors_in = [
         'errorType': 'invalid_type',
         'tableName': 'addresses',
         'columnName': 'addID',
-        'rowNumber': 1,
+        'rowNumbers': [1],
     },
     {
         'errorType': 'invalid_type',
         'tableName': 'addresses',
         'columnName': 'addID',
-        'rowNumber': 2,
+        'rowNumbers': [2],
     },
     {
         'errorType': 'invalid_type',
         'tableName': 'sites',
         'columnName': 'siteID',
-        'rowNumber': 1,
+        'rowNumbers': [1],
     },
 ]
 
@@ -69,7 +69,7 @@ warnings_in = [
         'warningType': '_coercion',
         'tableName': 'addresses',
         'columnName': 'addID',
-        'rowNumber': 1,
+        'rowNumbers': [1],
     },
     {
         'warningType': '_coercion',


### PR DESCRIPTION
ideally this would be split into two commits, but it became too much back and forth.

reports:
- use the same json-report fix everywhere

error props:
- merge rowNumber with rowNumbers
- merge row with rows

int-ranges:
- add support for single ints, so that `1` is used instead of `(1,1)`